### PR TITLE
feat: refactor client to support different auth methods

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -1,0 +1,68 @@
+package client
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type AuthProvider interface {
+	SetAuthHeader(req *http.Request) Error
+}
+
+type APITokenAuth struct {
+	token string
+}
+
+func NewAPITokenAuth(token string) AuthProvider {
+	return &APITokenAuth{token: token}
+}
+
+func (a *APITokenAuth) SetAuthHeader(req *http.Request) Error {
+	req.Header.Add("Authorization", fmt.Sprintf("NIRMATA-API %s", a.token))
+	return nil
+}
+
+type JWTTokenAuth struct {
+	token string
+}
+
+func NewJWTTokenAuth(token string) AuthProvider {
+	return &JWTTokenAuth{token: token}
+}
+
+func (a *JWTTokenAuth) SetAuthHeader(req *http.Request) Error {
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", a.token))
+	return nil
+}
+
+type ServiceAccountTokenAuth struct {
+	serviceAccountToken string
+
+	/*The JWT token is fetched using the
+	service account token and is short lived
+	*/
+	jwtToken string
+}
+
+func NewServiceAccountTokenAuth(serviceAccountToken string) AuthProvider {
+	return &ServiceAccountTokenAuth{serviceAccountToken: serviceAccountToken, jwtToken: ""}
+}
+
+func (a *ServiceAccountTokenAuth) SetAuthHeader(req *http.Request) Error {
+	if a.jwtToken == "" || IsJwtTokenExpired(a.jwtToken) {
+		jwtToken, err := a.FetchJWTToken()
+		if err != nil {
+			return err
+		}
+		a.jwtToken = jwtToken
+	}
+
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", a.jwtToken))
+	return nil
+}
+
+func (a *ServiceAccountTokenAuth) FetchJWTToken() (string, Error) {
+	// Fetch the JWT token using the service account token
+	// TODO: Implement custom logic for fetching the JWT token
+	return "placeHolder", nil
+}

--- a/auth.go
+++ b/auth.go
@@ -3,6 +3,7 @@ package client
 import (
 	"fmt"
 	"net/http"
+	"sync"
 )
 
 type AuthProvider interface {
@@ -36,33 +37,52 @@ func (a *JWTTokenAuth) SetAuthHeader(req *http.Request) Error {
 }
 
 type ServiceAccountTokenAuth struct {
+	Address             string
 	serviceAccountToken string
-
-	/*The JWT token is fetched using the
-	service account token and is short lived
-	*/
-	jwtToken string
+	clientid            string
+	jwtToken            string
+	mu                  sync.Mutex
 }
 
-func NewServiceAccountTokenAuth(serviceAccountToken string) AuthProvider {
-	return &ServiceAccountTokenAuth{serviceAccountToken: serviceAccountToken, jwtToken: ""}
+func NewServiceAccountTokenAuth(serviceAccountToken string, address string, clientid string) AuthProvider {
+	return &ServiceAccountTokenAuth{
+		serviceAccountToken: serviceAccountToken,
+		Address:             address,
+		jwtToken:            "",
+		clientid:            clientid,
+	}
 }
 
 func (a *ServiceAccountTokenAuth) SetAuthHeader(req *http.Request) Error {
 	if a.jwtToken == "" || IsJwtTokenExpired(a.jwtToken) {
-		jwtToken, err := a.FetchJWTToken()
+		a.mu.Lock()
+		jwtToken, err := a.fetchJWTToken()
 		if err != nil {
-			return err
+			a.mu.Unlock()
+			return NewError("ErrorHTTP", "Failed to fetch JWT token", err)
 		}
 		a.jwtToken = jwtToken
+		a.mu.Unlock()
 	}
 
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", a.jwtToken))
 	return nil
 }
 
-func (a *ServiceAccountTokenAuth) FetchJWTToken() (string, Error) {
-	// Fetch the JWT token using the service account token
-	// TODO: Implement custom logic for fetching the JWT token
-	return "placeHolder", nil
+func (a *ServiceAccountTokenAuth) fetchJWTToken() (string, Error) {
+	return exchangeServiceAccountTokenForJWTToken(a.serviceAccountToken, a.Address, a.clientid)
+}
+
+// NullAuth implements AuthProvider for no authentication
+type NullAuth struct{}
+
+// NewNullAuth creates a new null authentication provider that sets no auth headers
+func NewNullAuth() AuthProvider {
+	return &NullAuth{}
+}
+
+// SetAuthHeader does not set any authorization header
+func (a *NullAuth) SetAuthHeader(req *http.Request) Error {
+	// No authentication header is set
+	return nil
 }

--- a/auth.go
+++ b/auth.go
@@ -40,8 +40,12 @@ type ServiceAccountTokenAuth struct {
 	Address             string
 	serviceAccountToken string
 	clientid            string
-	jwtToken            string
-	mu                  sync.Mutex
+
+	/*The JWT token is fetched using the
+	service account token and is short lived
+	*/
+	jwtToken string
+	mu       sync.Mutex
 }
 
 func NewServiceAccountTokenAuth(serviceAccountToken string, address string, clientid string) AuthProvider {

--- a/auth_utils.go
+++ b/auth_utils.go
@@ -1,0 +1,33 @@
+package client
+
+import (
+	"k8s.io/klog/v2"
+)
+
+func exchangeServiceAccountTokenForJWTToken(serviceAccountToken string, address string, clientid string) (string, Error) {
+	// Create a client with NullAuth since this endpoint doesn't require authentication
+	c := NewClient(address, NewNullAuth(), false)
+
+	klog.V(3).Infof("Exchanging service account token for JWT")
+
+	// Prepare the request data
+	requestData := map[string]interface{}{
+		"grant_type":    "client_credentials",
+		"client_id":     clientid,
+		"client_secret": serviceAccountToken,
+	}
+
+	// Use the client's PostFromJSON method to make the request
+	response, err := c.PostFromJSON(ServiceSecurity, "auth/token", requestData, nil)
+	if err != nil {
+		return "", NewError("ErrorHTTP", "Failed to exchange service account token for JWT", err)
+	}
+
+	// Extract the access_token from the response
+	if token, ok := response["access_token"].(string); ok && token != "" {
+		klog.V(3).Infof("Successfully exchanged service account token for JWT")
+		return token, nil
+	}
+
+	return "", NewError("ErrorHTTP", "No access_token found in response", nil)
+}

--- a/auth_utils_test.go
+++ b/auth_utils_test.go
@@ -1,0 +1,34 @@
+package client
+
+import (
+	"testing"
+)
+
+func TestExchangeServiceAccountTokenForJWTToken_Success(t *testing.T) {
+	// Real server credentials
+	address := "https://devtest2.nirmata.co"
+	serviceAccountToken := "910a4190-d428-4eec-b890-59911d107b48"
+	clientID := "clientId"
+
+	// Test the function with real server
+	token, err := exchangeServiceAccountTokenForJWTToken(serviceAccountToken, address, clientID)
+
+	// Verify the result
+	if err != nil {
+		t.Fatalf("Failed to exchange service account token for JWT: %v", err)
+	}
+
+	// Verify we got a non-empty JWT token
+	if token == "" {
+		t.Fatal("Expected a non-empty JWT token, got empty string")
+	}
+
+	t.Logf("Successfully obtained JWT token (length: %d characters)", len(token))
+
+	// Show token preview (first 20 chars or full token if shorter)
+	previewLen := 20
+	if len(token) < previewLen {
+		previewLen = len(token)
+	}
+	t.Logf("Token preview: %s...", token[:previewLen])
+}

--- a/client.go
+++ b/client.go
@@ -78,6 +78,10 @@ type Client interface {
 	// Post is used to create a new model object.
 	Post(rr *RESTRequest) (map[string]interface{}, Error)
 
+	// PostRaw is used to send a request to a custom REST endpoint. The contentType is assumed to be JSON. The queryParams is optional.
+	// The response is returned as a raw HTTP response.
+	PostRaw(rr *RESTRequest) (*http.Response, error)
+
 	// Post is used to create a new model object. The contentType is assumed to be JSON. The queryParams is optional.
 	PostFromJSON(service Service, path string, jsonMap map[string]interface{}, queryParams map[string]string) (map[string]interface{}, Error)
 

--- a/client.go
+++ b/client.go
@@ -81,6 +81,10 @@ type Client interface {
 	// Post is used to create a new model object. The contentType is assumed to be JSON. The queryParams is optional.
 	PostFromJSON(service Service, path string, jsonMap map[string]interface{}, queryParams map[string]string) (map[string]interface{}, Error)
 
+	// PostRawFromJSON is used send a request to a custom REST endpoint. The contentType is assumed to be JSON. The queryParams is optional.
+	// The response is returned as a raw HTTP response.
+	PostRawFromJSON(service Service, path string, jsonMap map[string]interface{}, queryParams map[string]string) (*http.Response, error)
+
 	// Post is used to create resources or call a custom REST endpoint. The contentType is assumed to be YAML.
 	// The path and queryParams are optional
 	PostWithID(id ID, path string, data []byte, queryParams map[string]string) (map[string]interface{}, Error)

--- a/client.go
+++ b/client.go
@@ -102,9 +102,6 @@ type Client interface {
 
 	// SetAuth sets the authentication provider to be used for subsequent requests
 	SetAuth(auth AuthProvider)
-
-	// FetchJWTToken fetches a new JWT token
-	FetchJWTToken() (string, Error)
 }
 
 // GetOptions contains optional paramameters used when retrieving objects
@@ -153,8 +150,8 @@ func NewClientWithJWTToken(address string, jwtToken string, insecure bool) Clien
 	return NewClient(address, NewJWTTokenAuth(jwtToken), insecure)
 }
 
-func NewClientWithServiceAccountToken(address string, serviceAccountToken string, insecure bool) Client {
-	return NewClient(address, NewServiceAccountTokenAuth(serviceAccountToken), insecure)
+func NewClientWithServiceAccountToken(address string, serviceAccountToken string, clientid string, insecure bool) Client {
+	return NewClient(address, NewServiceAccountTokenAuth(serviceAccountToken, address, clientid), insecure)
 }
 
 type client struct {

--- a/client.go
+++ b/client.go
@@ -639,6 +639,7 @@ func (c *client) buildRequest(method string, rr *RESTRequest) (*http.Request, Er
 }
 
 // sendRaw sends an HTTP request and returns the raw response without processing
+// The caller is responsible for closing the response body.
 func (c *client) sendAndGetRawResponse(request *http.Request) (*http.Response, error) {
 	klog.V(3).Infof("HTTP request method=%s URL=%s", request.Method, request.URL.String())
 	klog.V(3).Infof("HTTP request body=%s", dumpRequest(request))
@@ -648,7 +649,6 @@ func (c *client) sendAndGetRawResponse(request *http.Request) (*http.Response, e
 		return resp, err
 	}
 
-	defer resp.Body.Close()
 	klog.V(3).Infof("HTTP response status=%s", resp.Status)
 	return resp, nil
 }

--- a/samples/.gitignore
+++ b/samples/.gitignore
@@ -1,0 +1,27 @@
+# Compiled binaries
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool
+*.out
+
+# Go workspace file
+go.work
+
+# Build artifacts
+/bin/
+/build/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+

--- a/samples/QUICKSTART.md
+++ b/samples/QUICKSTART.md
@@ -1,0 +1,188 @@
+# Quick Start Guide
+
+## Setup
+
+```bash
+# Set your Nirmata URL
+export NIRMATA_URL="https://your-nirmata-instance.com"
+
+# Set at least one authentication token
+export NIRMATA_API_TOKEN="your-api-token"
+export NIRMATA_JWT_TOKEN="your-jwt-token"        # optional
+export NIRMATA_SA_TOKEN="your-sa-token"          # optional
+```
+
+## Authentication Methods
+
+### 1. API Token Authentication
+
+```go
+import "github.com/nirmata/go-client"
+
+// Quick way
+client := client.NewClientWithAPIKey(address, apiToken, false)
+
+// Explicit way
+auth := client.NewAPITokenAuth(apiToken)
+client := client.NewClient(address, auth, false)
+```
+
+**Header Format:** `Authorization: NIRMATA-API {token}`
+
+### 2. JWT Token Authentication
+
+```go
+import "github.com/nirmata/go-client"
+
+// Quick way
+client := client.NewClientWithJWTToken(address, jwtToken, false)
+
+// Explicit way
+auth := client.NewJWTTokenAuth(jwtToken)
+client := client.NewClient(address, auth, false)
+```
+
+**Header Format:** `Authorization: Bearer {token}`
+
+### 3. Service Account Token Authentication
+
+```go
+import "github.com/nirmata/go-client"
+
+// Quick way
+client := client.NewClientWithServiceAccountToken(address, saToken, false)
+
+// Explicit way
+auth := client.NewServiceAccountTokenAuth(saToken)
+client := client.NewClient(address, auth, false)
+```
+
+**Header Format:** `Authorization: Bearer {token}` (extensible)
+
+### 4. Switch Authentication at Runtime
+
+```go
+// Start with API token
+client := client.NewClientWithAPIKey(address, apiToken, false)
+
+// Switch to JWT
+jwtAuth := client.NewJWTTokenAuth(jwtToken)
+client.SetAuth(jwtAuth)
+
+// Switch to Service Account
+saAuth := client.NewServiceAccountTokenAuth(saToken)
+client.SetAuth(saAuth)
+```
+
+## Common Operations
+
+### Fetch a Collection
+
+```go
+// Get all environments
+environments, err := client.GetCollection(
+    client.ServiceEnvironments,
+    "environments",
+    nil,
+)
+if err != nil {
+    // handle error
+}
+```
+
+### Fetch with Options
+
+```go
+// Create query
+query := client.NewQuery().FieldEqualsValue("name", "production")
+
+// Create options
+opts := client.NewGetOptions(
+    []string{"name", "id", "description"},
+    query,
+)
+
+// Fetch with options
+items, err := client.GetCollection(
+    client.ServiceEnvironments,
+    "environments",
+    opts,
+)
+```
+
+### Get Single Object
+
+```go
+// Parse an ID
+id, err := client.ParseID(idString)
+if err != nil {
+    // handle error
+}
+
+// Get the object
+obj, err := client.Get(id, nil)
+if err != nil {
+    // handle error
+}
+```
+
+## Run Samples
+
+```bash
+# Run individual samples (from root directory)
+go run ./samples/api-token-auth
+go run ./samples/jwt-token-auth
+go run ./samples/service-account-auth
+go run ./samples/switch-auth
+go run ./samples/custom-auth
+
+# Run comprehensive example
+go run ./samples/complete-demo
+
+# Or navigate to a sample directory and run
+cd samples/api-token-auth && go run .
+```
+
+## Custom Authentication
+
+Implement the `AuthProvider` interface:
+
+```go
+type CustomAuth struct {
+    token string
+}
+
+func (a *CustomAuth) SetAuthHeader(req *http.Request) client.Error {
+    req.Header.Add("Authorization", "Custom " + a.token)
+    // Add any custom logic here
+    return nil
+}
+
+// Use it
+auth := &CustomAuth{token: "my-token"}
+client := client.NewClient(address, auth, false)
+```
+
+## Best Practices
+
+1. **Never hardcode tokens** - Use environment variables or secure storage
+2. **Choose the right auth method** - API tokens for services, JWT for users
+3. **Handle errors properly** - Always check for authentication errors
+4. **Rotate tokens regularly** - Implement token refresh for long-running apps
+5. **Use HTTPS in production** - Set `insecure` parameter to `false`
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| "No auth provider configured" | Create client with an AuthProvider |
+| 401 Unauthorized | Verify token is valid and has correct permissions |
+| Connection refused | Check NIRMATA_URL is correct and accessible |
+| Token expired | Refresh token and call `SetAuth()` with new token |
+
+## Next Steps
+
+- Review [README.md](README.md) for detailed examples
+- See [custom-auth/main.go](custom-auth/main.go) for advanced authentication patterns
+- Check the main [go-client documentation](../README.md) for full API reference
+

--- a/samples/QUICKSTART.md
+++ b/samples/QUICKSTART.md
@@ -50,14 +50,14 @@ client := client.NewClient(address, auth, false)
 import "github.com/nirmata/go-client"
 
 // Quick way
-client := client.NewClientWithServiceAccountToken(address, saToken, false)
+client := client.NewClientWithServiceAccountToken(address, saToken, "client-id", false)
 
 // Explicit way
-auth := client.NewServiceAccountTokenAuth(saToken)
+auth := client.NewServiceAccountTokenAuth(saToken, address, "client-id")
 client := client.NewClient(address, auth, false)
 ```
 
-**Header Format:** `Authorization: Bearer {token}` (extensible)
+**Header Format:** `Authorization: Bearer {token}` (automatically exchanges SA token for JWT)
 
 ### 4. Switch Authentication at Runtime
 
@@ -70,7 +70,7 @@ jwtAuth := client.NewJWTTokenAuth(jwtToken)
 client.SetAuth(jwtAuth)
 
 // Switch to Service Account
-saAuth := client.NewServiceAccountTokenAuth(saToken)
+saAuth := client.NewServiceAccountTokenAuth(saToken, address, "client-id")
 client.SetAuth(saAuth)
 ```
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,0 +1,101 @@
+# Go-Client Samples
+
+This directory contains sample code demonstrating how to use the go-client library with different authentication mechanisms.
+
+> 📋 See [STRUCTURE.md](STRUCTURE.md) for the complete directory structure and organization details.
+
+## Samples
+
+1. **[api-token-auth/](api-token-auth/)** - Basic API token authentication
+2. **[jwt-token-auth/](jwt-token-auth/)** - JWT token authentication
+3. **[service-account-auth/](service-account-auth/)** - Service account token authentication
+4. **[switch-auth/](switch-auth/)** - Switching authentication at runtime
+5. **[custom-auth/](custom-auth/)** - Implementing a custom authentication provider
+6. **[complete-demo/](complete-demo/)** - Complete example with all authentication methods
+
+## Running the Samples
+
+Each sample is in its own directory with its own `main.go` file.
+
+To run a sample:
+
+```bash
+# Set environment variables
+export NIRMATA_URL="https://your-nirmata-instance.com"
+export NIRMATA_API_TOKEN="your-api-token"
+export NIRMATA_JWT_TOKEN="your-jwt-token"       # optional
+export NIRMATA_SA_TOKEN="your-service-account-token"  # optional
+
+# Run a specific sample (from the samples directory)
+cd samples/api-token-auth && go run .
+cd samples/jwt-token-auth && go run .
+cd samples/service-account-auth && go run .
+cd samples/switch-auth && go run .
+cd samples/custom-auth && go run .
+cd samples/complete-demo && go run .
+
+# Or from the root directory
+go run ./samples/api-token-auth
+go run ./samples/jwt-token-auth
+go run ./samples/complete-demo
+```
+
+## Prerequisites
+
+- Go 1.16 or higher
+- Access to a Nirmata instance
+- Valid authentication credentials (API token, JWT token, or service account token)
+
+## Authentication Methods
+
+### API Token Authentication
+Traditional token-based authentication using the `NIRMATA-API` header format.
+
+### JWT Token Authentication
+JSON Web Token authentication using the `Bearer` token format.
+
+### Service Account Token Authentication
+Service account token authentication (extensible for custom implementations).
+
+## Common Patterns
+
+### Creating a Client
+```go
+// With API token
+client := client.NewClientWithAPIKey(address, apiToken, false)
+
+// With JWT token
+client := client.NewClientWithJWTToken(address, jwtToken, false)
+
+// With service account token
+client := client.NewClientWithServiceAccountToken(address, saToken, false)
+
+// With custom auth provider
+auth := client.NewAPITokenAuth(token)
+client := client.NewClient(address, auth, false)
+```
+
+### Switching Authentication
+```go
+// Create client with one auth method
+client := client.NewClientWithAPIKey(address, apiToken, false)
+
+// Switch to another auth method
+newAuth := client.NewJWTTokenAuth(jwtToken)
+client.SetAuth(newAuth)
+```
+
+## Error Handling
+
+All samples include proper error handling. Always check for errors when:
+- Creating clients
+- Making API calls
+- Processing responses
+
+## Security Notes
+
+- Never hardcode credentials in your source code
+- Use environment variables or secure configuration management
+- Rotate tokens regularly
+- Use the minimum required permissions
+

--- a/samples/README.md
+++ b/samples/README.md
@@ -68,7 +68,7 @@ client := client.NewClientWithAPIKey(address, apiToken, false)
 client := client.NewClientWithJWTToken(address, jwtToken, false)
 
 // With service account token
-client := client.NewClientWithServiceAccountToken(address, saToken, false)
+client := client.NewClientWithServiceAccountToken(address, saToken, "client-id", false)
 
 // With custom auth provider
 auth := client.NewAPITokenAuth(token)

--- a/samples/STRUCTURE.md
+++ b/samples/STRUCTURE.md
@@ -1,0 +1,68 @@
+# Samples Directory Structure
+
+```
+samples/
+├── README.md                          # Main documentation
+├── QUICKSTART.md                      # Quick reference guide  
+├── STRUCTURE.md                       # This file
+├── .gitignore                         # Git ignore rules
+│
+├── api-token-auth/                    # API Token Authentication
+│   └── main.go                        # Standalone example
+│
+├── jwt-token-auth/                    # JWT Token Authentication
+│   └── main.go                        # Standalone example
+│
+├── service-account-auth/              # Service Account Token Authentication
+│   └── main.go                        # Standalone example
+│
+├── switch-auth/                       # Runtime Auth Switching
+│   └── main.go                        # Demonstrates SetAuth()
+│
+├── custom-auth/                       # Custom Auth Provider
+│   └── main.go                        # Advanced patterns
+│
+└── complete-demo/                     # Comprehensive Demo
+    └── main.go                        # All auth methods in one
+```
+
+## Design
+
+Each sample is a standalone Go program in its own directory:
+- **Self-contained**: Each has its own `main.go` with a complete example
+- **Independent**: Can be run without affecting other samples
+- **No conflicts**: Separate directories prevent `main()` declaration conflicts
+
+## Running
+
+```bash
+# From project root
+go run ./samples/api-token-auth
+go run ./samples/jwt-token-auth
+go run ./samples/complete-demo
+
+# From within a sample directory
+cd samples/api-token-auth
+go run .
+```
+
+## Building
+
+```bash
+# Build all samples at once (from project root)
+go build ./samples/...
+
+# Build a specific sample
+go build ./samples/api-token-auth
+```
+
+## Adding New Samples
+
+To add a new sample:
+
+1. Create a new directory: `mkdir samples/my-new-sample`
+2. Create `main.go` inside: `touch samples/my-new-sample/main.go`
+3. Write your sample with `package main` and `func main()`
+4. Update the README.md to list the new sample
+5. Test: `go run ./samples/my-new-sample`
+

--- a/samples/api-token-auth/main.go
+++ b/samples/api-token-auth/main.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/nirmata/go-client"
+)
+
+// This example demonstrates how to create a client with API token authentication
+func main() {
+	// Get configuration from environment variables
+	address := os.Getenv("NIRMATA_URL")
+	apiToken := os.Getenv("NIRMATA_API_TOKEN")
+
+	if address == "" || apiToken == "" {
+		fmt.Println("Error: NIRMATA_URL and NIRMATA_API_TOKEN environment variables must be set")
+		os.Exit(1)
+	}
+
+	// Method 1: Using the convenience constructor (recommended)
+	fmt.Println("Creating client with API token (Method 1)...")
+	client1 := client.NewClientWithAPIKey(address, apiToken, false)
+
+	// Method 2: Using the base constructor with auth provider
+	fmt.Println("Creating client with API token (Method 2)...")
+	apiAuth := client.NewAPITokenAuth(apiToken)
+	client2 := client.NewClient(address, apiAuth, false)
+
+	// Verify the clients work
+	fmt.Printf("Client 1 address: %s\n", client1.Address())
+	fmt.Printf("Client 2 address: %s\n", client2.Address())
+
+	// Example: Get a collection
+	fmt.Println("\nFetching environments...")
+	environments, err := client1.GetCollection(client.ServiceEnvironments, "environments", nil)
+	if err != nil {
+		fmt.Printf("Error fetching environments: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Found %d environment(s)\n", len(environments))
+	for i, env := range environments {
+		if name, ok := env["name"].(string); ok {
+			fmt.Printf("  %d. %s\n", i+1, name)
+		}
+	}
+
+	fmt.Println("\n✓ API token authentication successful!")
+}

--- a/samples/complete-demo/main.go
+++ b/samples/complete-demo/main.go
@@ -1,0 +1,226 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/nirmata/go-client"
+)
+
+func main() {
+	fmt.Println("╔══════════════════════════════════════════════════════════════╗")
+	fmt.Println("║   Go-Client Authentication Examples                         ║")
+	fmt.Println("╚══════════════════════════════════════════════════════════════╝")
+	fmt.Println()
+
+	// Get configuration from environment variables
+	address := os.Getenv("NIRMATA_URL")
+	apiToken := os.Getenv("NIRMATA_API_TOKEN")
+	jwtToken := os.Getenv("NIRMATA_JWT_TOKEN")
+	saToken := os.Getenv("NIRMATA_SA_TOKEN")
+
+	if address == "" {
+		fmt.Println("❌ Error: NIRMATA_URL environment variable must be set")
+		printUsage()
+		os.Exit(1)
+	}
+
+	// Track which auth methods are available
+	hasAPIToken := apiToken != ""
+	hasJWTToken := jwtToken != ""
+	hasSAToken := saToken != ""
+
+	if !hasAPIToken && !hasJWTToken && !hasSAToken {
+		fmt.Println("❌ Error: At least one authentication token must be set")
+		printUsage()
+		os.Exit(1)
+	}
+
+	fmt.Println("Configuration:")
+	fmt.Printf("  • Server URL: %s\n", address)
+	fmt.Printf("  • API Token: %s\n", boolToStatus(hasAPIToken))
+	fmt.Printf("  • JWT Token: %s\n", boolToStatus(hasJWTToken))
+	fmt.Printf("  • SA Token:  %s\n", boolToStatus(hasSAToken))
+	fmt.Println()
+
+	// Example 1: API Token Authentication
+	if hasAPIToken {
+		fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+		fmt.Println("1️⃣  API Token Authentication")
+		fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+
+		// Method 1: Convenience constructor
+		c1 := client.NewClientWithAPIKey(address, apiToken, false)
+		fmt.Println("   ✓ Client created using NewClientWithAPIKey()")
+
+		// Method 2: Using auth provider
+		apiAuth := client.NewAPITokenAuth(apiToken)
+		c2 := client.NewClient(address, apiAuth, false)
+		fmt.Println("   ✓ Client created using NewClient() with APITokenAuth")
+
+		// Test the client
+		if err := testClient(c1, "API Token"); err != nil {
+			fmt.Printf("   ❌ API Token authentication failed: %v\n", err)
+		} else {
+			fmt.Println("   ✓ API Token authentication successful!")
+		}
+		fmt.Println()
+
+		_ = c2 // Used to show alternative creation method
+	}
+
+	// Example 2: JWT Token Authentication
+	if hasJWTToken {
+		fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+		fmt.Println("2️⃣  JWT Token Authentication")
+		fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+
+		// Method 1: Convenience constructor
+		c1 := client.NewClientWithJWTToken(address, jwtToken, false)
+		fmt.Println("   ✓ Client created using NewClientWithJWTToken()")
+
+		// Method 2: Using auth provider
+		jwtAuth := client.NewJWTTokenAuth(jwtToken)
+		c2 := client.NewClient(address, jwtAuth, false)
+		fmt.Println("   ✓ Client created using NewClient() with JWTTokenAuth")
+
+		// Test the client
+		if err := testClient(c1, "JWT Token"); err != nil {
+			fmt.Printf("   ❌ JWT Token authentication failed: %v\n", err)
+		} else {
+			fmt.Println("   ✓ JWT Token authentication successful!")
+		}
+		fmt.Println()
+
+		_ = c2 // Used to show alternative creation method
+	}
+
+	// Example 3: Service Account Token Authentication
+	if hasSAToken {
+		fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+		fmt.Println("3️⃣  Service Account Token Authentication")
+		fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+
+		// Method 1: Convenience constructor
+		c1 := client.NewClientWithServiceAccountToken(address, saToken, false)
+		fmt.Println("   ✓ Client created using NewClientWithServiceAccountToken()")
+
+		// Method 2: Using auth provider
+		saAuth := client.NewServiceAccountTokenAuth(saToken)
+		c2 := client.NewClient(address, saAuth, false)
+		fmt.Println("   ✓ Client created using NewClient() with ServiceAccountTokenAuth")
+
+		// Test the client
+		if err := testClient(c1, "Service Account Token"); err != nil {
+			fmt.Printf("   ❌ Service Account Token authentication failed: %v\n", err)
+		} else {
+			fmt.Println("   ✓ Service Account Token authentication successful!")
+		}
+		fmt.Println()
+
+		_ = c2 // Used to show alternative creation method
+	}
+
+	// Example 4: Switching Authentication at Runtime
+	if hasAPIToken && hasJWTToken {
+		fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+		fmt.Println("4️⃣  Runtime Authentication Switching")
+		fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+
+		// Start with API token
+		c := client.NewClientWithAPIKey(address, apiToken, false)
+		fmt.Println("   ✓ Client created with API Token")
+
+		// Test with API token
+		if err := testClient(c, "API Token (initial)"); err == nil {
+			fmt.Println("   ✓ Request successful with API Token")
+		}
+
+		// Switch to JWT token
+		jwtAuth := client.NewJWTTokenAuth(jwtToken)
+		c.SetAuth(jwtAuth)
+		fmt.Println("   ✓ Switched to JWT Token authentication")
+
+		// Test with JWT token
+		if err := testClient(c, "JWT Token (switched)"); err == nil {
+			fmt.Println("   ✓ Request successful with JWT Token")
+		}
+
+		// Switch back to API token
+		apiAuth := client.NewAPITokenAuth(apiToken)
+		c.SetAuth(apiAuth)
+		fmt.Println("   ✓ Switched back to API Token authentication")
+
+		fmt.Println("   ✓ Runtime authentication switching demonstrated!")
+		fmt.Println()
+	}
+
+	// Summary
+	fmt.Println("╔══════════════════════════════════════════════════════════════╗")
+	fmt.Println("║   Summary                                                    ║")
+	fmt.Println("╚══════════════════════════════════════════════════════════════╝")
+	fmt.Println()
+	fmt.Println("The go-client library supports flexible authentication:")
+	fmt.Println()
+	fmt.Println("📌 Three Built-in Authentication Methods:")
+	fmt.Println("   • API Token (NIRMATA-API header)")
+	fmt.Println("   • JWT Token (Bearer token)")
+	fmt.Println("   • Service Account Token (Bearer token, extensible)")
+	fmt.Println()
+	fmt.Println("📌 Two Ways to Create Clients:")
+	fmt.Println("   • Convenience constructors (e.g., NewClientWithAPIKey)")
+	fmt.Println("   • Base constructor with AuthProvider (NewClient)")
+	fmt.Println()
+	fmt.Println("📌 Runtime Authentication Switching:")
+	fmt.Println("   • Use SetAuth() to change authentication on existing clients")
+	fmt.Println()
+	fmt.Println("📌 Extensibility:")
+	fmt.Println("   • Implement AuthProvider interface for custom auth")
+	fmt.Println("   • See custom_auth.go for examples")
+	fmt.Println()
+	fmt.Println("✅ All authentication methods tested successfully!")
+	fmt.Println()
+}
+
+// testClient tests a client by making a simple API call
+func testClient(c client.Client, authType string) error {
+	fmt.Printf("   Testing with %s...\n", authType)
+
+	// Try to fetch environments (a simple read operation)
+	envs, err := c.GetCollection(client.ServiceEnvironments, "environments", nil)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("   ✓ Fetched %d environment(s)\n", len(envs))
+	return nil
+}
+
+// boolToStatus converts a boolean to a status string
+func boolToStatus(b bool) string {
+	if b {
+		return "✓ Set"
+	}
+	return "✗ Not set"
+}
+
+// printUsage prints usage information
+func printUsage() {
+	fmt.Println()
+	fmt.Println("Usage:")
+	fmt.Println("  Set the following environment variables:")
+	fmt.Println()
+	fmt.Println("  Required:")
+	fmt.Println("    NIRMATA_URL           - Your Nirmata instance URL")
+	fmt.Println()
+	fmt.Println("  At least one of:")
+	fmt.Println("    NIRMATA_API_TOKEN     - API token for authentication")
+	fmt.Println("    NIRMATA_JWT_TOKEN     - JWT token for authentication")
+	fmt.Println("    NIRMATA_SA_TOKEN      - Service account token for authentication")
+	fmt.Println()
+	fmt.Println("Example:")
+	fmt.Println("  export NIRMATA_URL=\"https://your-instance.nirmata.io\"")
+	fmt.Println("  export NIRMATA_API_TOKEN=\"your-api-token\"")
+	fmt.Println("  go run samples/main.go")
+	fmt.Println()
+}

--- a/samples/complete-demo/main.go
+++ b/samples/complete-demo/main.go
@@ -102,11 +102,11 @@ func main() {
 		fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
 
 		// Method 1: Convenience constructor
-		c1 := client.NewClientWithServiceAccountToken(address, saToken, false)
+		c1 := client.NewClientWithServiceAccountToken(address, saToken, "client-id", false)
 		fmt.Println("   ✓ Client created using NewClientWithServiceAccountToken()")
 
 		// Method 2: Using auth provider
-		saAuth := client.NewServiceAccountTokenAuth(saToken)
+		saAuth := client.NewServiceAccountTokenAuth(saToken, address, "client-id")
 		c2 := client.NewClient(address, saAuth, false)
 		fmt.Println("   ✓ Client created using NewClient() with ServiceAccountTokenAuth")
 

--- a/samples/custom-auth/main.go
+++ b/samples/custom-auth/main.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/nirmata/go-client"
+)
+
+// CustomAuth is an example of a custom authentication provider
+// This example implements a simple auth provider that adds multiple headers
+type CustomAuth struct {
+	apiKey    string
+	userAgent string
+	timestamp time.Time
+}
+
+// NewCustomAuth creates a new custom authentication provider
+func NewCustomAuth(apiKey, userAgent string) client.AuthProvider {
+	return &CustomAuth{
+		apiKey:    apiKey,
+		userAgent: userAgent,
+		timestamp: time.Now(),
+	}
+}
+
+// SetAuthHeader implements the AuthProvider interface
+func (a *CustomAuth) SetAuthHeader(req *http.Request) client.Error {
+	// Add the authorization header
+	req.Header.Add("Authorization", fmt.Sprintf("Custom-Token %s", a.apiKey))
+
+	// Add custom headers
+	req.Header.Add("X-User-Agent", a.userAgent)
+	req.Header.Add("X-Auth-Timestamp", a.timestamp.Format(time.RFC3339))
+	req.Header.Add("X-Custom-Auth", "true")
+
+	fmt.Printf("[CustomAuth] Setting auth headers for request to: %s\n", req.URL.Path)
+
+	return nil
+}
+
+// RotatingAuth is a more advanced example that refreshes tokens
+type RotatingAuth struct {
+	currentToken string
+	refreshFunc  func() (string, error)
+	lastRefresh  time.Time
+	refreshAfter time.Duration
+}
+
+// NewRotatingAuth creates an authentication provider that refreshes tokens
+func NewRotatingAuth(initialToken string, refreshFunc func() (string, error), refreshAfter time.Duration) client.AuthProvider {
+	return &RotatingAuth{
+		currentToken: initialToken,
+		refreshFunc:  refreshFunc,
+		lastRefresh:  time.Now(),
+		refreshAfter: refreshAfter,
+	}
+}
+
+// SetAuthHeader implements the AuthProvider interface with token rotation
+func (a *RotatingAuth) SetAuthHeader(req *http.Request) client.Error {
+	// Check if we need to refresh the token
+	if time.Since(a.lastRefresh) > a.refreshAfter {
+		fmt.Println("[RotatingAuth] Token expired, refreshing...")
+		newToken, err := a.refreshFunc()
+		if err != nil {
+			return client.NewError("ErrorAuth", "Failed to refresh token", err)
+		}
+		a.currentToken = newToken
+		a.lastRefresh = time.Now()
+		fmt.Println("[RotatingAuth] Token refreshed successfully")
+	}
+
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", a.currentToken))
+	return nil
+}
+
+func main() {
+	// Get configuration from environment variables
+	address := os.Getenv("NIRMATA_URL")
+	apiToken := os.Getenv("NIRMATA_API_TOKEN")
+
+	if address == "" || apiToken == "" {
+		fmt.Println("Error: NIRMATA_URL and NIRMATA_API_TOKEN environment variables must be set")
+		os.Exit(1)
+	}
+
+	// Example 1: Using CustomAuth
+	fmt.Println("Example 1: Custom Authentication with Multiple Headers")
+	fmt.Println("======================================================")
+
+	customAuth := NewCustomAuth(apiToken, "MyCustomApp/1.0")
+	customClient := client.NewClient(address, customAuth, false)
+
+	fmt.Printf("Client created with custom auth provider\n")
+	fmt.Printf("Address: %s\n\n", customClient.Address())
+
+	// Note: This will fail unless your backend accepts "Custom-Token" format
+	// This is just to demonstrate the concept
+	fmt.Println("Note: This custom auth format is for demonstration purposes.")
+	fmt.Println("Your backend would need to support the custom header format.\n")
+
+	// Example 2: Using RotatingAuth
+	fmt.Println("Example 2: Rotating Token Authentication")
+	fmt.Println("=========================================")
+
+	// Define a token refresh function
+	refreshFunc := func() (string, error) {
+		// In a real application, this would fetch a new token from an auth server
+		fmt.Println("  → Fetching new token from auth server...")
+		time.Sleep(100 * time.Millisecond) // Simulate network delay
+
+		// For this example, we'll just return the same token
+		// In production, you'd make an HTTP request to get a new token
+		return apiToken, nil
+	}
+
+	// Create a rotating auth provider that refreshes every 30 seconds
+	rotatingAuth := NewRotatingAuth(apiToken, refreshFunc, 30*time.Second)
+	rotatingClient := client.NewClient(address, rotatingAuth, false)
+
+	fmt.Printf("Client created with rotating auth provider\n")
+	fmt.Printf("Token will refresh every 30 seconds\n")
+	fmt.Printf("Address: %s\n\n", rotatingClient.Address())
+
+	// Make a request with standard API token auth to verify everything works
+	fmt.Println("Example 3: Using Standard Auth for Actual Request")
+	fmt.Println("==================================================")
+
+	standardClient := client.NewClientWithAPIKey(address, apiToken, false)
+
+	envs, err := standardClient.GetCollection(client.ServiceEnvironments, "environments", nil)
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("✓ Successfully fetched %d environments\n", len(envs))
+
+	fmt.Println("\n======================================================================")
+	fmt.Println("Key Takeaways:")
+	fmt.Println("======================================================================")
+	fmt.Println("1. Custom auth providers must implement the AuthProvider interface")
+	fmt.Println("2. The SetAuthHeader method receives the HTTP request and can modify headers")
+	fmt.Println("3. You can implement any authentication logic (rotation, refresh, multi-header, etc.)")
+	fmt.Println("4. Custom providers integrate seamlessly with the client")
+	fmt.Println("======================================================================")
+}

--- a/samples/jwt-token-auth/main.go
+++ b/samples/jwt-token-auth/main.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/nirmata/go-client"
+)
+
+// This example demonstrates how to create a client with JWT token authentication
+func main() {
+	// Get configuration from environment variables
+	address := os.Getenv("NIRMATA_URL")
+	jwtToken := os.Getenv("NIRMATA_JWT_TOKEN")
+
+	if address == "" || jwtToken == "" {
+		fmt.Println("Error: NIRMATA_URL and NIRMATA_JWT_TOKEN environment variables must be set")
+		os.Exit(1)
+	}
+
+	// Method 1: Using the convenience constructor (recommended)
+	fmt.Println("Creating client with JWT token (Method 1)...")
+	client1 := client.NewClientWithJWTToken(address, jwtToken, false)
+
+	// Method 2: Using the base constructor with auth provider
+	fmt.Println("Creating client with JWT token (Method 2)...")
+	jwtAuth := client.NewJWTTokenAuth(jwtToken)
+	client2 := client.NewClient(address, jwtAuth, false)
+
+	// Verify the clients work
+	fmt.Printf("Client 1 address: %s\n", client1.Address())
+	fmt.Printf("Client 2 address: %s\n", client2.Address())
+
+	// Example: Get a collection
+	fmt.Println("\nFetching clusters...")
+	clusters, err := client1.GetCollection(client.ServiceClusters, "clusters", nil)
+	if err != nil {
+		fmt.Printf("Error fetching clusters: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Found %d cluster(s)\n", len(clusters))
+	for i, cluster := range clusters {
+		if name, ok := cluster["name"].(string); ok {
+			fmt.Printf("  %d. %s\n", i+1, name)
+		}
+	}
+
+	fmt.Println("\n✓ JWT token authentication successful!")
+}

--- a/samples/service-account-auth/main.go
+++ b/samples/service-account-auth/main.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/nirmata/go-client"
+)
+
+// This example demonstrates how to create a client with service account token authentication
+func main() {
+	// Get configuration from environment variables
+	address := os.Getenv("NIRMATA_URL")
+	saToken := os.Getenv("NIRMATA_SA_TOKEN")
+
+	if address == "" || saToken == "" {
+		fmt.Println("Error: NIRMATA_URL and NIRMATA_SA_TOKEN environment variables must be set")
+		os.Exit(1)
+	}
+
+	// Method 1: Using the convenience constructor (recommended)
+	fmt.Println("Creating client with service account token (Method 1)...")
+	client1 := client.NewClientWithServiceAccountToken(address, saToken, false)
+
+	// Method 2: Using the base constructor with auth provider
+	fmt.Println("Creating client with service account token (Method 2)...")
+	saAuth := client.NewServiceAccountTokenAuth(saToken)
+	client2 := client.NewClient(address, saAuth, false)
+
+	// Verify the clients work
+	fmt.Printf("Client 1 address: %s\n", client1.Address())
+	fmt.Printf("Client 2 address: %s\n", client2.Address())
+
+	// Example: Get a collection
+	fmt.Println("\nFetching namespaces...")
+	namespaces, err := client1.GetCollection(client.ServiceEnvironments, "namespaces", nil)
+	if err != nil {
+		fmt.Printf("Error fetching namespaces: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Found %d namespace(s)\n", len(namespaces))
+	for i, ns := range namespaces {
+		if name, ok := ns["name"].(string); ok {
+			fmt.Printf("  %d. %s\n", i+1, name)
+		}
+	}
+
+	fmt.Println("\n✓ Service account token authentication successful!")
+	fmt.Println("\nNote: Service account authentication currently uses the same Bearer token format")
+	fmt.Println("as JWT tokens. Custom logic can be added to the ServiceAccountTokenAuth implementation.")
+}

--- a/samples/service-account-auth/main.go
+++ b/samples/service-account-auth/main.go
@@ -20,11 +20,11 @@ func main() {
 
 	// Method 1: Using the convenience constructor (recommended)
 	fmt.Println("Creating client with service account token (Method 1)...")
-	client1 := client.NewClientWithServiceAccountToken(address, saToken, false)
+	client1 := client.NewClientWithServiceAccountToken(address, saToken, "client-id", false)
 
 	// Method 2: Using the base constructor with auth provider
 	fmt.Println("Creating client with service account token (Method 2)...")
-	saAuth := client.NewServiceAccountTokenAuth(saToken)
+	saAuth := client.NewServiceAccountTokenAuth(saToken, address, "client-id")
 	client2 := client.NewClient(address, saAuth, false)
 
 	// Verify the clients work

--- a/serviceclients/usersclient.go
+++ b/serviceclients/usersclient.go
@@ -19,15 +19,14 @@ type User struct {
 	TenantID string
 }
 
-func New(address, apiKey string, insecure bool) *UsersClient {
-	client := client.NewClient(address, apiKey, insecure)
-	return &UsersClient{Client: client}
+func New(address string, auth client.AuthProvider, insecure bool) *UsersClient {
+	return &UsersClient{Client: client.NewClient(address, auth, insecure)}
 }
 
-func (c *UsersClient) GetCurrentUser() (User, error) {
+func (c *UsersClient) GetCurrentUserWithAPIKey(apiKey string) (User, error) {
 	fields := []string{"name", "email", "role", "id", "parent"}
 
-	urlEncodedAPIKey := url.QueryEscape(c.Client.APIKey())
+	urlEncodedAPIKey := url.QueryEscape(apiKey)
 
 	query := client.NewQuery().FieldEqualsValue("apiKey", urlEncodedAPIKey)
 	users, err := c.Client.GetCollection(client.ServiceUsers, "users", client.NewGetOptions(fields, query))

--- a/serviceclients/usersclient.go
+++ b/serviceclients/usersclient.go
@@ -19,7 +19,7 @@ type User struct {
 	TenantID string
 }
 
-func New(address string, auth client.AuthProvider, insecure bool) *UsersClient {
+func NewUsersClient(address string, auth client.AuthProvider, insecure bool) *UsersClient {
 	return &UsersClient{Client: client.NewClient(address, auth, insecure)}
 }
 

--- a/services.go
+++ b/services.go
@@ -16,6 +16,7 @@ const (
 	ServiceSecurity
 	ServiceConfig
 	ServicePolicies
+	ServiceLLMAPPS
 )
 
 // Name returns the service name
@@ -41,6 +42,9 @@ func (s Service) Name() string {
 
 	case ServicePolicies:
 		return "policies"
+
+	case ServiceLLMAPPS:
+		return "llm-apps"
 
 	default:
 		return ""
@@ -71,6 +75,8 @@ func ParseService(s string) (Service, error) {
 	case "policies":
 		return ServicePolicies, nil
 
+	case "llm-apps":
+		return ServiceLLMAPPS, nil
 	}
 
 	return -1, fmt.Errorf("invalid service %s", s)

--- a/urlBuilder.go
+++ b/urlBuilder.go
@@ -47,7 +47,9 @@ func (ub *urlBldr) ToService(s Service) URLBuilder {
 		ub.paths = append(ub.paths, s.Name())
 	}
 	ub.paths = append(ub.paths, s.Name())
-	ub.paths = append(ub.paths, "api")
+	if s != ServiceLLMAPPS {
+		ub.paths = append(ub.paths, "api")
+	}
 	return ub
 }
 

--- a/urlBuilder.go
+++ b/urlBuilder.go
@@ -47,7 +47,7 @@ func (ub *urlBldr) ToService(s Service) URLBuilder {
 		ub.paths = append(ub.paths, s.Name())
 	}
 	ub.paths = append(ub.paths, s.Name())
-	if s != ServiceLLMAPPS {
+	if s != ServiceLLMApps {
 		ub.paths = append(ub.paths, "api")
 	}
 	return ub

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,205 @@
+package client
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestIsJwtTokenExpired_ValidNotExpiredToken(t *testing.T) {
+	// expires on 1764166688
+	jwtToken := "eyJhbGciOiJSUzI1NiJ9.eyJOYW1lIjoiYXJhc2gtdGVzdC0xMCIsInN1YiI6Ijk3MjI4ZTIzLTViOTMtNDdhZi1iNWJiLThjM2YzOTBlMGUwMiIsImlzcyI6IlNlY3VyaXR5IiwiYXVkIjoiIiwiUm9sZXMiOiJkZXZvcHMiLCJHcm91cHMiOiIiLCJUZW5hbnQgSUQiOiJiODUxODNkNC1mZmFhLTRiOTItOGI4Ny03ZWExYzc3YWZhYTQiLCJQcmluY2lwbGUgVHlwZSI6IlNlcnZpY2VBY2NvdW50IiwiZXhwIjoxNzY0MTY2Njg4fQ.jh5DzCIsYAk5NbsqSgWVYxU0JlDXTBTAmWWDj7saKV4B1l4aYSoaEm--h6uiyyc019TP_z2KHEwbjaZQNAFPoHYikDIWI_MYmkyDb-mj0oXJbU6AHcfKtruCmvluRRG-zf-7Y3zfrTJrHqls8Qi06AOZaaxF-HZsil_DrpdR83HaEN5SLizmu_aK8kpcxsgFZiuVAmgqcrsF4UrrSMAeO_-6BI8bj0q0x2pEvL_6-XswKBSsyc680k-Hnlrgkif9JAcCkT3QkVBJDlG8EZwAXZQ4R4girbdehts7pQ6YIPNdvrJX4Kt7F7EoEvUxv38wvr7VUX4I_MQsGfBiec_h5A"
+
+	isExpired := IsJwtTokenExpired(jwtToken)
+
+	// This token expires on March 26, 2025, so it should NOT be expired as of Nov 2024
+	if isExpired {
+		t.Error("Expected token to NOT be expired (expires in 2025), but got expired")
+	}
+
+	t.Logf("✓ Token is not expired (expires: 1764166688)")
+}
+
+func TestIsJwtTokenExpired_ExpiredToken(t *testing.T) {
+	// Create a JWT token that expired in the past
+	expiredToken := createTestJWT(time.Now().Add(-1 * time.Hour).Unix()) // Expired 1 hour ago
+
+	isExpired := IsJwtTokenExpired(expiredToken)
+
+	if !isExpired {
+		t.Error("Expected token to be expired, but got not expired")
+	}
+
+	t.Logf("✓ Token is correctly identified as expired")
+}
+
+func TestIsJwtTokenExpired_TokenExpiringInFuture(t *testing.T) {
+	// Create a JWT token that expires 1 hour from now
+	futureToken := createTestJWT(time.Now().Add(1 * time.Hour).Unix())
+
+	isExpired := IsJwtTokenExpired(futureToken)
+
+	if isExpired {
+		t.Error("Expected token to NOT be expired (expires in 1 hour), but got expired")
+	}
+
+	t.Logf("✓ Token expiring in future is correctly identified as not expired")
+}
+
+func TestIsJwtTokenExpired_TokenExpiringNow(t *testing.T) {
+	// Create a JWT token that expires exactly now (edge case)
+	nowToken := createTestJWT(time.Now().Unix())
+
+	isExpired := IsJwtTokenExpired(nowToken)
+
+	// Token expiring at current time should be considered expired
+	if !isExpired {
+		t.Error("Expected token expiring at current time to be expired, but got not expired")
+	}
+
+	t.Logf("✓ Token expiring at current time is correctly identified as expired")
+}
+
+func TestIsJwtTokenExpired_InvalidToken(t *testing.T) {
+	// Invalid JWT format (not enough parts)
+	invalidToken := "invalid.token"
+
+	isExpired := IsJwtTokenExpired(invalidToken)
+
+	// Invalid tokens should be treated as expired
+	if !isExpired {
+		t.Error("Expected invalid token to be treated as expired, but got not expired")
+	}
+
+	t.Logf("✓ Invalid token is correctly treated as expired")
+}
+
+func TestIsJwtTokenExpired_TokenWithoutExpField(t *testing.T) {
+	// Create a JWT token without exp field
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"sub":"test","name":"Test User"}`))
+	signature := base64.RawURLEncoding.EncodeToString([]byte("fake-signature"))
+	tokenWithoutExp := fmt.Sprintf("%s.%s.%s", header, payload, signature)
+
+	isExpired := IsJwtTokenExpired(tokenWithoutExp)
+
+	// Token without exp field should be treated as expired
+	if !isExpired {
+		t.Error("Expected token without exp field to be treated as expired, but got not expired")
+	}
+
+	t.Logf("✓ Token without exp field is correctly treated as expired")
+}
+
+func TestIsJwtTokenExpired_EmptyToken(t *testing.T) {
+	// Empty token string
+	emptyToken := ""
+
+	isExpired := IsJwtTokenExpired(emptyToken)
+
+	// Empty token should be treated as expired
+	if !isExpired {
+		t.Error("Expected empty token to be treated as expired, but got not expired")
+	}
+
+	t.Logf("✓ Empty token is correctly treated as expired")
+}
+
+func TestIsJwtTokenExpired_TokenWithInvalidBase64(t *testing.T) {
+	// Token with invalid base64 encoding
+	invalidBase64Token := "header.@@invalid@@base64.signature"
+
+	isExpired := IsJwtTokenExpired(invalidBase64Token)
+
+	// Token with invalid base64 should be treated as expired
+	if !isExpired {
+		t.Error("Expected token with invalid base64 to be treated as expired, but got not expired")
+	}
+
+	t.Logf("✓ Token with invalid base64 is correctly treated as expired")
+}
+
+func TestIsJwtTokenExpired_TokenWithInvalidJSON(t *testing.T) {
+	// Token with invalid JSON in payload
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(`{not valid json}`))
+	signature := base64.RawURLEncoding.EncodeToString([]byte("fake-signature"))
+	invalidJSONToken := fmt.Sprintf("%s.%s.%s", header, payload, signature)
+
+	isExpired := IsJwtTokenExpired(invalidJSONToken)
+
+	// Token with invalid JSON should be treated as expired
+	if !isExpired {
+		t.Error("Expected token with invalid JSON to be treated as expired, but got not expired")
+	}
+
+	t.Logf("✓ Token with invalid JSON is correctly treated as expired")
+}
+
+func TestIsJwtTokenExpired_TokenWithStringExpField(t *testing.T) {
+	// Token with exp as string instead of number
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"sub":"test","exp":"not-a-number"}`))
+	signature := base64.RawURLEncoding.EncodeToString([]byte("fake-signature"))
+	stringExpToken := fmt.Sprintf("%s.%s.%s", header, payload, signature)
+
+	isExpired := IsJwtTokenExpired(stringExpToken)
+
+	// Token with invalid exp format should be treated as expired
+	if !isExpired {
+		t.Error("Expected token with string exp field to be treated as expired, but got not expired")
+	}
+
+	t.Logf("✓ Token with invalid exp format is correctly treated as expired")
+}
+
+func TestIsJwtTokenExpired_TokenJustExpired(t *testing.T) {
+	// Token that expired 1 second ago
+	justExpiredToken := createTestJWT(time.Now().Add(-1 * time.Second).Unix())
+
+	isExpired := IsJwtTokenExpired(justExpiredToken)
+
+	if !isExpired {
+		t.Error("Expected token expired 1 second ago to be expired, but got not expired")
+	}
+
+	t.Logf("✓ Token that just expired is correctly identified as expired")
+}
+
+func TestIsJwtTokenExpired_TokenExpiringFarInFuture(t *testing.T) {
+	// Token that expires 1 year from now
+	farFutureToken := createTestJWT(time.Now().Add(365 * 24 * time.Hour).Unix())
+
+	isExpired := IsJwtTokenExpired(farFutureToken)
+
+	if isExpired {
+		t.Error("Expected token expiring in 1 year to NOT be expired, but got expired")
+	}
+
+	t.Logf("✓ Token expiring far in future is correctly identified as not expired")
+}
+
+// Helper function to create test JWT tokens with specific expiry times
+func createTestJWT(expiryUnix int64) string {
+	header := map[string]interface{}{
+		"alg": "RS256",
+		"typ": "JWT",
+	}
+
+	payload := map[string]interface{}{
+		"sub":  "test-user",
+		"name": "Test User",
+		"exp":  expiryUnix,
+	}
+
+	headerJSON, _ := json.Marshal(header)
+	payloadJSON, _ := json.Marshal(payload)
+
+	headerEncoded := base64.RawURLEncoding.EncodeToString(headerJSON)
+	payloadEncoded := base64.RawURLEncoding.EncodeToString(payloadJSON)
+	signatureEncoded := base64.RawURLEncoding.EncodeToString([]byte("fake-signature-for-testing"))
+
+	return fmt.Sprintf("%s.%s.%s", headerEncoded, payloadEncoded, signatureEncoded)
+}


### PR DESCRIPTION
# Refactor Authentication System to Support Multiple Auth Methods

## Overview
This PR refactors the authentication system to use an interface-based design that supports multiple authentication methods: API tokens, JWT tokens, and service account tokens. The new design is more flexible, extensible, and maintains a clean separation of concerns.

## Key Changes

### 1. New Authentication Architecture

#### Added `AuthProvider` Interface (`auth.go`)
- Created `AuthProvider` interface with `SetAuthHeader(req *http.Request) Error` method
- Implemented three authentication providers:
  - **`APITokenAuth`**: API token authentication (`NIRMATA-API` header format)
  - **`JWTTokenAuth`**: JWT token authentication (`Bearer` token format)
  - **`ServiceAccountTokenAuth`**: Service account token authentication (extensible placeholder)

#### Refactored Client Structure (`client.go`)
- **Removed**: Individual `apiToken` and `jwtToken` fields
- **Added**: Single `authProvider AuthProvider` field
- **Simplified**: `SetAuthorizationHeader()` now delegates to the auth provider
- **Removed**: JWT token expiry checking logic (no longer built into client)

### 2. New Client Constructors

#### Updated Constructors
- `NewClient(address, auth, insecure)` - Base constructor accepting any `AuthProvider`
- `NewClientWithAPIKey(address, apiKey, insecure)` - Convenience for API token auth
- `NewClientWithJWTToken(address, jwtToken, insecure)` - Convenience for JWT token auth
- `NewClientWithServiceAccountToken(address, saToken, insecure)` - Convenience for SA token auth

#### Runtime Auth Switching
- Added `SetAuth(auth AuthProvider)` method to change authentication at runtime
- Allows switching between auth methods without recreating the client

### 3. API Changes

#### Removed Methods
- `SetJWTToken(jwtToken string)` - No longer needed with auth provider pattern
- `APIKey() string` - Removed as token is now encapsulated in auth provider

#### Removed from Interface
- `SetJWTToken()` method removed from `Client` interface
- `APIKey()` method removed from `Client` interface

#### Added to Interface
- `SetAuth(auth AuthProvider)` - Set/change authentication provider

### 4. Updated Dependencies

#### Fixed `serviceclients/usersclient.go`
- Updated to use `NewClientWithAPIKey()` constructor
- Removed dependency on removed `APIKey()` method

### 5. Comprehensive Samples

Created `samples/` directory with working examples:
