### PR TITLE
feat: add serviceAccountToken Auth

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -3,6 +3,7 @@ package client
 import (
 	"fmt"
 	"net/http"
+	"sync"
 )
 
 type AuthProvider interface {
@@ -36,33 +37,52 @@ func (a *JWTTokenAuth) SetAuthHeader(req *http.Request) Error {
 }
 
 type ServiceAccountTokenAuth struct {
+	Address             string
 	serviceAccountToken string
-
-	/*The JWT token is fetched using the
-	service account token and is short lived
-	*/
-	jwtToken string
+	clientid            string
+	jwtToken            string
+	mu                  sync.Mutex
 }
 
-func NewServiceAccountTokenAuth(serviceAccountToken string) AuthProvider {
-	return &ServiceAccountTokenAuth{serviceAccountToken: serviceAccountToken, jwtToken: ""}
+func NewServiceAccountTokenAuth(serviceAccountToken string, address string, clientid string) AuthProvider {
+	return &ServiceAccountTokenAuth{
+		serviceAccountToken: serviceAccountToken,
+		Address:             address,
+		jwtToken:            "",
+		clientid:            clientid,
+	}
 }
 
 func (a *ServiceAccountTokenAuth) SetAuthHeader(req *http.Request) Error {
 	if a.jwtToken == "" || IsJwtTokenExpired(a.jwtToken) {
-		jwtToken, err := a.FetchJWTToken()
+		a.mu.Lock()
+		jwtToken, err := a.fetchJWTToken()
 		if err != nil {
-			return err
+			a.mu.Unlock()
+			return NewError("ErrorHTTP", "Failed to fetch JWT token", err)
 		}
 		a.jwtToken = jwtToken
+		a.mu.Unlock()
 	}
 
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", a.jwtToken))
 	return nil
 }
 
-func (a *ServiceAccountTokenAuth) FetchJWTToken() (string, Error) {
-	// Fetch the JWT token using the service account token
-	// TODO: Implement custom logic for fetching the JWT token
-	return "placeHolder", nil
+func (a *ServiceAccountTokenAuth) fetchJWTToken() (string, Error) {
+	return exchangeServiceAccountTokenForJWTToken(a.serviceAccountToken, a.Address, a.clientid)
+}
+
+// NullAuth implements AuthProvider for no authentication
+type NullAuth struct{}
+
+// NewNullAuth creates a new null authentication provider that sets no auth headers
+func NewNullAuth() AuthProvider {
+	return &NullAuth{}
+}
+
+// SetAuthHeader does not set any authorization header
+func (a *NullAuth) SetAuthHeader(req *http.Request) Error {
+	// No authentication header is set
+	return nil
 }

--- a/auth.go
+++ b/auth.go
@@ -40,8 +40,12 @@ type ServiceAccountTokenAuth struct {
 	Address             string
 	serviceAccountToken string
 	clientid            string
-	jwtToken            string
-	mu                  sync.Mutex
+
+	/*The JWT token is fetched using the
+	service account token and is short lived
+	*/
+	jwtToken string
+	mu       sync.Mutex
 }
 
 func NewServiceAccountTokenAuth(serviceAccountToken string, address string, clientid string) AuthProvider {

--- a/auth_utils.go
+++ b/auth_utils.go
@@ -1,0 +1,33 @@
+package client
+
+import (
+	"k8s.io/klog/v2"
+)
+
+func exchangeServiceAccountTokenForJWTToken(serviceAccountToken string, address string, clientid string) (string, Error) {
+	// Create a client with NullAuth since this endpoint doesn't require authentication
+	c := NewClient(address, NewNullAuth(), false)
+
+	klog.V(3).Infof("Exchanging service account token for JWT")
+
+	// Prepare the request data
+	requestData := map[string]interface{}{
+		"grant_type":    "client_credentials",
+		"client_id":     clientid,
+		"client_secret": serviceAccountToken,
+	}
+
+	// Use the client's PostFromJSON method to make the request
+	response, err := c.PostFromJSON(ServiceSecurity, "auth/token", requestData, nil)
+	if err != nil {
+		return "", NewError("ErrorHTTP", "Failed to exchange service account token for JWT", err)
+	}
+
+	// Extract the access_token from the response
+	if token, ok := response["access_token"].(string); ok && token != "" {
+		klog.V(3).Infof("Successfully exchanged service account token for JWT")
+		return token, nil
+	}
+
+	return "", NewError("ErrorHTTP", "No access_token found in response", nil)
+}

--- a/auth_utils_test.go
+++ b/auth_utils_test.go
@@ -1,0 +1,34 @@
+package client
+
+import (
+	"testing"
+)
+
+func TestExchangeServiceAccountTokenForJWTToken_Success(t *testing.T) {
+	// Real server credentials
+	address := "https://devtest2.nirmata.co"
+	serviceAccountToken := "910a4190-d428-4eec-b890-59911d107b48"
+	clientID := "clientId"
+
+	// Test the function with real server
+	token, err := exchangeServiceAccountTokenForJWTToken(serviceAccountToken, address, clientID)
+
+	// Verify the result
+	if err != nil {
+		t.Fatalf("Failed to exchange service account token for JWT: %v", err)
+	}
+
+	// Verify we got a non-empty JWT token
+	if token == "" {
+		t.Fatal("Expected a non-empty JWT token, got empty string")
+	}
+
+	t.Logf("Successfully obtained JWT token (length: %d characters)", len(token))
+
+	// Show token preview (first 20 chars or full token if shorter)
+	previewLen := 20
+	if len(token) < previewLen {
+		previewLen = len(token)
+	}
+	t.Logf("Token preview: %s...", token[:previewLen])
+}

--- a/client.go
+++ b/client.go
@@ -102,9 +102,6 @@ type Client interface {
 
 	// SetAuth sets the authentication provider to be used for subsequent requests
 	SetAuth(auth AuthProvider)
-
-	// FetchJWTToken fetches a new JWT token
-	FetchJWTToken() (string, Error)
 }
 
 // GetOptions contains optional paramameters used when retrieving objects
@@ -153,8 +150,8 @@ func NewClientWithJWTToken(address string, jwtToken string, insecure bool) Clien
 	return NewClient(address, NewJWTTokenAuth(jwtToken), insecure)
 }
 
-func NewClientWithServiceAccountToken(address string, serviceAccountToken string, insecure bool) Client {
-	return NewClient(address, NewServiceAccountTokenAuth(serviceAccountToken), insecure)
+func NewClientWithServiceAccountToken(address string, serviceAccountToken string, clientid string, insecure bool) Client {
+	return NewClient(address, NewServiceAccountTokenAuth(serviceAccountToken, address, clientid), insecure)
 }
 
 type client struct {

--- a/samples/QUICKSTART.md
+++ b/samples/QUICKSTART.md
@@ -50,14 +50,14 @@ client := client.NewClient(address, auth, false)
 import "github.com/nirmata/go-client"
 
 // Quick way
-client := client.NewClientWithServiceAccountToken(address, saToken, false)
+client := client.NewClientWithServiceAccountToken(address, saToken, "client-id", false)
 
 // Explicit way
-auth := client.NewServiceAccountTokenAuth(saToken)
+auth := client.NewServiceAccountTokenAuth(saToken, address, "client-id")
 client := client.NewClient(address, auth, false)
 ```
 
-**Header Format:** `Authorization: Bearer {token}` (extensible)
+**Header Format:** `Authorization: Bearer {token}` (automatically exchanges SA token for JWT)
 
 ### 4. Switch Authentication at Runtime
 
@@ -70,7 +70,7 @@ jwtAuth := client.NewJWTTokenAuth(jwtToken)
 client.SetAuth(jwtAuth)
 
 // Switch to Service Account
-saAuth := client.NewServiceAccountTokenAuth(saToken)
+saAuth := client.NewServiceAccountTokenAuth(saToken, address, "client-id")
 client.SetAuth(saAuth)
 ```
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -68,7 +68,7 @@ client := client.NewClientWithAPIKey(address, apiToken, false)
 client := client.NewClientWithJWTToken(address, jwtToken, false)
 
 // With service account token
-client := client.NewClientWithServiceAccountToken(address, saToken, false)
+client := client.NewClientWithServiceAccountToken(address, saToken, "client-id", false)
 
 // With custom auth provider
 auth := client.NewAPITokenAuth(token)

--- a/samples/complete-demo/main.go
+++ b/samples/complete-demo/main.go
@@ -102,11 +102,11 @@ func main() {
 		fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
 
 		// Method 1: Convenience constructor
-		c1 := client.NewClientWithServiceAccountToken(address, saToken, false)
+		c1 := client.NewClientWithServiceAccountToken(address, saToken, "client-id", false)
 		fmt.Println("   ✓ Client created using NewClientWithServiceAccountToken()")
 
 		// Method 2: Using auth provider
-		saAuth := client.NewServiceAccountTokenAuth(saToken)
+		saAuth := client.NewServiceAccountTokenAuth(saToken, address, "client-id")
 		c2 := client.NewClient(address, saAuth, false)
 		fmt.Println("   ✓ Client created using NewClient() with ServiceAccountTokenAuth")
 

--- a/samples/service-account-auth/main.go
+++ b/samples/service-account-auth/main.go
@@ -20,11 +20,11 @@ func main() {
 
 	// Method 1: Using the convenience constructor (recommended)
 	fmt.Println("Creating client with service account token (Method 1)...")
-	client1 := client.NewClientWithServiceAccountToken(address, saToken, false)
+	client1 := client.NewClientWithServiceAccountToken(address, saToken, "client-id", false)
 
 	// Method 2: Using the base constructor with auth provider
 	fmt.Println("Creating client with service account token (Method 2)...")
-	saAuth := client.NewServiceAccountTokenAuth(saToken)
+	saAuth := client.NewServiceAccountTokenAuth(saToken, address, "client-id")
 	client2 := client.NewClient(address, saAuth, false)
 
 	// Verify the clients work

--- a/serviceclients/usersclient.go
+++ b/serviceclients/usersclient.go
@@ -19,7 +19,7 @@ type User struct {
 	TenantID string
 }
 
-func New(address string, auth client.AuthProvider, insecure bool) *UsersClient {
+func NewUsersClient(address string, auth client.AuthProvider, insecure bool) *UsersClient {
 	return &UsersClient{Client: client.NewClient(address, auth, insecure)}
 }
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,205 @@
+package client
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestIsJwtTokenExpired_ValidNotExpiredToken(t *testing.T) {
+	// expires on 1764166688
+	jwtToken := "eyJhbGciOiJSUzI1NiJ9.eyJOYW1lIjoiYXJhc2gtdGVzdC0xMCIsInN1YiI6Ijk3MjI4ZTIzLTViOTMtNDdhZi1iNWJiLThjM2YzOTBlMGUwMiIsImlzcyI6IlNlY3VyaXR5IiwiYXVkIjoiIiwiUm9sZXMiOiJkZXZvcHMiLCJHcm91cHMiOiIiLCJUZW5hbnQgSUQiOiJiODUxODNkNC1mZmFhLTRiOTItOGI4Ny03ZWExYzc3YWZhYTQiLCJQcmluY2lwbGUgVHlwZSI6IlNlcnZpY2VBY2NvdW50IiwiZXhwIjoxNzY0MTY2Njg4fQ.jh5DzCIsYAk5NbsqSgWVYxU0JlDXTBTAmWWDj7saKV4B1l4aYSoaEm--h6uiyyc019TP_z2KHEwbjaZQNAFPoHYikDIWI_MYmkyDb-mj0oXJbU6AHcfKtruCmvluRRG-zf-7Y3zfrTJrHqls8Qi06AOZaaxF-HZsil_DrpdR83HaEN5SLizmu_aK8kpcxsgFZiuVAmgqcrsF4UrrSMAeO_-6BI8bj0q0x2pEvL_6-XswKBSsyc680k-Hnlrgkif9JAcCkT3QkVBJDlG8EZwAXZQ4R4girbdehts7pQ6YIPNdvrJX4Kt7F7EoEvUxv38wvr7VUX4I_MQsGfBiec_h5A"
+
+	isExpired := IsJwtTokenExpired(jwtToken)
+
+	// This token expires on March 26, 2025, so it should NOT be expired as of Nov 2024
+	if isExpired {
+		t.Error("Expected token to NOT be expired (expires in 2025), but got expired")
+	}
+
+	t.Logf("✓ Token is not expired (expires: 1764166688)")
+}
+
+func TestIsJwtTokenExpired_ExpiredToken(t *testing.T) {
+	// Create a JWT token that expired in the past
+	expiredToken := createTestJWT(time.Now().Add(-1 * time.Hour).Unix()) // Expired 1 hour ago
+
+	isExpired := IsJwtTokenExpired(expiredToken)
+
+	if !isExpired {
+		t.Error("Expected token to be expired, but got not expired")
+	}
+
+	t.Logf("✓ Token is correctly identified as expired")
+}
+
+func TestIsJwtTokenExpired_TokenExpiringInFuture(t *testing.T) {
+	// Create a JWT token that expires 1 hour from now
+	futureToken := createTestJWT(time.Now().Add(1 * time.Hour).Unix())
+
+	isExpired := IsJwtTokenExpired(futureToken)
+
+	if isExpired {
+		t.Error("Expected token to NOT be expired (expires in 1 hour), but got expired")
+	}
+
+	t.Logf("✓ Token expiring in future is correctly identified as not expired")
+}
+
+func TestIsJwtTokenExpired_TokenExpiringNow(t *testing.T) {
+	// Create a JWT token that expires exactly now (edge case)
+	nowToken := createTestJWT(time.Now().Unix())
+
+	isExpired := IsJwtTokenExpired(nowToken)
+
+	// Token expiring at current time should be considered expired
+	if !isExpired {
+		t.Error("Expected token expiring at current time to be expired, but got not expired")
+	}
+
+	t.Logf("✓ Token expiring at current time is correctly identified as expired")
+}
+
+func TestIsJwtTokenExpired_InvalidToken(t *testing.T) {
+	// Invalid JWT format (not enough parts)
+	invalidToken := "invalid.token"
+
+	isExpired := IsJwtTokenExpired(invalidToken)
+
+	// Invalid tokens should be treated as expired
+	if !isExpired {
+		t.Error("Expected invalid token to be treated as expired, but got not expired")
+	}
+
+	t.Logf("✓ Invalid token is correctly treated as expired")
+}
+
+func TestIsJwtTokenExpired_TokenWithoutExpField(t *testing.T) {
+	// Create a JWT token without exp field
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"sub":"test","name":"Test User"}`))
+	signature := base64.RawURLEncoding.EncodeToString([]byte("fake-signature"))
+	tokenWithoutExp := fmt.Sprintf("%s.%s.%s", header, payload, signature)
+
+	isExpired := IsJwtTokenExpired(tokenWithoutExp)
+
+	// Token without exp field should be treated as expired
+	if !isExpired {
+		t.Error("Expected token without exp field to be treated as expired, but got not expired")
+	}
+
+	t.Logf("✓ Token without exp field is correctly treated as expired")
+}
+
+func TestIsJwtTokenExpired_EmptyToken(t *testing.T) {
+	// Empty token string
+	emptyToken := ""
+
+	isExpired := IsJwtTokenExpired(emptyToken)
+
+	// Empty token should be treated as expired
+	if !isExpired {
+		t.Error("Expected empty token to be treated as expired, but got not expired")
+	}
+
+	t.Logf("✓ Empty token is correctly treated as expired")
+}
+
+func TestIsJwtTokenExpired_TokenWithInvalidBase64(t *testing.T) {
+	// Token with invalid base64 encoding
+	invalidBase64Token := "header.@@invalid@@base64.signature"
+
+	isExpired := IsJwtTokenExpired(invalidBase64Token)
+
+	// Token with invalid base64 should be treated as expired
+	if !isExpired {
+		t.Error("Expected token with invalid base64 to be treated as expired, but got not expired")
+	}
+
+	t.Logf("✓ Token with invalid base64 is correctly treated as expired")
+}
+
+func TestIsJwtTokenExpired_TokenWithInvalidJSON(t *testing.T) {
+	// Token with invalid JSON in payload
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(`{not valid json}`))
+	signature := base64.RawURLEncoding.EncodeToString([]byte("fake-signature"))
+	invalidJSONToken := fmt.Sprintf("%s.%s.%s", header, payload, signature)
+
+	isExpired := IsJwtTokenExpired(invalidJSONToken)
+
+	// Token with invalid JSON should be treated as expired
+	if !isExpired {
+		t.Error("Expected token with invalid JSON to be treated as expired, but got not expired")
+	}
+
+	t.Logf("✓ Token with invalid JSON is correctly treated as expired")
+}
+
+func TestIsJwtTokenExpired_TokenWithStringExpField(t *testing.T) {
+	// Token with exp as string instead of number
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"sub":"test","exp":"not-a-number"}`))
+	signature := base64.RawURLEncoding.EncodeToString([]byte("fake-signature"))
+	stringExpToken := fmt.Sprintf("%s.%s.%s", header, payload, signature)
+
+	isExpired := IsJwtTokenExpired(stringExpToken)
+
+	// Token with invalid exp format should be treated as expired
+	if !isExpired {
+		t.Error("Expected token with string exp field to be treated as expired, but got not expired")
+	}
+
+	t.Logf("✓ Token with invalid exp format is correctly treated as expired")
+}
+
+func TestIsJwtTokenExpired_TokenJustExpired(t *testing.T) {
+	// Token that expired 1 second ago
+	justExpiredToken := createTestJWT(time.Now().Add(-1 * time.Second).Unix())
+
+	isExpired := IsJwtTokenExpired(justExpiredToken)
+
+	if !isExpired {
+		t.Error("Expected token expired 1 second ago to be expired, but got not expired")
+	}
+
+	t.Logf("✓ Token that just expired is correctly identified as expired")
+}
+
+func TestIsJwtTokenExpired_TokenExpiringFarInFuture(t *testing.T) {
+	// Token that expires 1 year from now
+	farFutureToken := createTestJWT(time.Now().Add(365 * 24 * time.Hour).Unix())
+
+	isExpired := IsJwtTokenExpired(farFutureToken)
+
+	if isExpired {
+		t.Error("Expected token expiring in 1 year to NOT be expired, but got expired")
+	}
+
+	t.Logf("✓ Token expiring far in future is correctly identified as not expired")
+}
+
+// Helper function to create test JWT tokens with specific expiry times
+func createTestJWT(expiryUnix int64) string {
+	header := map[string]interface{}{
+		"alg": "RS256",
+		"typ": "JWT",
+	}
+
+	payload := map[string]interface{}{
+		"sub":  "test-user",
+		"name": "Test User",
+		"exp":  expiryUnix,
+	}
+
+	headerJSON, _ := json.Marshal(header)
+	payloadJSON, _ := json.Marshal(payload)
+
+	headerEncoded := base64.RawURLEncoding.EncodeToString(headerJSON)
+	payloadEncoded := base64.RawURLEncoding.EncodeToString(payloadJSON)
+	signatureEncoded := base64.RawURLEncoding.EncodeToString([]byte("fake-signature-for-testing"))
+
+	return fmt.Sprintf("%s.%s.%s", headerEncoded, payloadEncoded, signatureEncoded)
+}


### PR DESCRIPTION
# Service Account Token Authentication Implementation

## Overview
Implements service account token authentication with automatic JWT token exchange and refresh.

## Key Changes

### 1. Service Account Token Authentication
- Implemented automatic JWT token exchange via `/security/auth/token` endpoint
- Exchanges service account tokens for JWT tokens using OAuth2 client credentials flow
- Automatically refreshes JWT when expired using `IsJwtTokenExpired()`
- Thread-safe token refresh with mutex locking to prevent race conditions

### 2. NullAuth Provider
- Added `NullAuth` implementation for unauthenticated endpoints
- Enables making requests without setting authorization headers
- Used internally for the token exchange endpoint

### 3. Token Exchange Implementation
- Created `exchangeServiceAccountTokenForJWTToken()` in `auth_utils.go`
- Uses client's `PostFromJSON()` method for consistency
- Sends OAuth2 client credentials grant request:
  - `grant_type`: `client_credentials`
  - `client_id`: configurable
  - `client_secret`: service account token
- Extracts `access_token` from response

### 4. Thread Safety
- Added `sync.Mutex` to `ServiceAccountTokenAuth`
- Locks during JWT token fetch and assignment
- Prevents concurrent token refresh requests

### 5. Comprehensive Testing
- **`auth_utils_test.go`**: Tests for JWT token exchange with real server integration
- **`utils_test.go`**: 12 test cases for `IsJwtTokenExpired()` covering:
  - Valid tokens (expired/not expired)
  - Edge cases (expiring now, just expired)
  - Error cases (invalid format, missing fields, malformed JSON)
  - Tokens with invalid base64 or exp field types
