### PR TITLE
feat: add support to fetch github app token from policies service

### DIFF
--- a/serviceclients/policiesclient.go
+++ b/serviceclients/policiesclient.go
@@ -1,0 +1,35 @@
+package serviceclients
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/nirmata/go-client"
+)
+
+type GithubAppAccessToken struct {
+	Token     string `json:"token"`
+	ExpiresAt string `json:"expires_at"`
+}
+
+type PoliciesClient struct {
+	Client client.Client
+}
+
+func NewPoliciesClient(address string, auth client.AuthProvider, insecure bool) *PoliciesClient {
+	return &PoliciesClient{Client: client.NewClient(address, auth, insecure)}
+}
+
+func (c *PoliciesClient) GetGithubAppAccessToken(installationOwner string) (*GithubAppAccessToken, error) {
+	res, _, reqErr := c.Client.GetURL(client.ServicePolicies, "github/accessToken/"+installationOwner)
+	if reqErr != nil {
+		return nil, fmt.Errorf("failed to get github app access token: %w", reqErr)
+	}
+
+	var githubAppAccessToken GithubAppAccessToken
+	err := json.Unmarshal(res, &githubAppAccessToken)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal github app access token: %w", err)
+	}
+	return &githubAppAccessToken, nil
+}

--- a/serviceclients/policiesclient.go
+++ b/serviceclients/policiesclient.go
@@ -21,7 +21,7 @@ func NewPoliciesClient(address string, auth client.AuthProvider, insecure bool) 
 }
 
 func (c *PoliciesClient) GetGithubAppAccessToken(installationOwner string) (*GithubAppAccessToken, error) {
-	res, _, reqErr := c.Client.GetURL(client.ServicePolicies, "github/accessToken/"+installationOwner)
+	res, _, reqErr := c.Client.GetURL(client.ServicePolicies, "github/accessToken?installationOwner="+installationOwner)
 	if reqErr != nil {
 		return nil, fmt.Errorf("failed to get github app access token: %w", reqErr)
 	}


### PR DESCRIPTION
Related PRs:
* https://github.com/nirmata/go-agent-remediator/pull/290
* https://github.com/nirmata/go-vcs/pull/21

Doc:
* [Enabling Remediator to use Nirmata Github App](https://docs.google.com/document/d/1au8o5OblVPjxeLJYQ40mjg3Dz8qAT9Bc5KaCGtcgao8/edit?usp=sharing)