### PR TITLE
fix: respect user's insecure parameter in service account token exchange

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -40,6 +40,7 @@ type ServiceAccountTokenAuth struct {
 	Address             string
 	serviceAccountToken string
 	clientid            string
+	insecure            bool
 
 	/*The JWT token is fetched using the
 	service account token and is short lived
@@ -48,12 +49,13 @@ type ServiceAccountTokenAuth struct {
 	mu       sync.Mutex
 }
 
-func NewServiceAccountTokenAuth(serviceAccountToken string, address string, clientid string) AuthProvider {
+func NewServiceAccountTokenAuth(serviceAccountToken string, address string, clientid string, insecure bool) AuthProvider {
 	return &ServiceAccountTokenAuth{
 		serviceAccountToken: serviceAccountToken,
 		Address:             address,
 		jwtToken:            "",
 		clientid:            clientid,
+		insecure:            insecure,
 	}
 }
 
@@ -74,7 +76,7 @@ func (a *ServiceAccountTokenAuth) SetAuthHeader(req *http.Request) Error {
 }
 
 func (a *ServiceAccountTokenAuth) fetchJWTToken() (string, Error) {
-	return exchangeServiceAccountTokenForJWTToken(a.serviceAccountToken, a.Address, a.clientid)
+	return exchangeServiceAccountTokenForJWTToken(a.serviceAccountToken, a.Address, a.clientid, a.insecure)
 }
 
 // NullAuth implements AuthProvider for no authentication

--- a/auth_utils.go
+++ b/auth_utils.go
@@ -4,10 +4,9 @@ import (
 	"k8s.io/klog/v2"
 )
 
-func exchangeServiceAccountTokenForJWTToken(serviceAccountToken string, address string, clientid string) (string, Error) {
+func exchangeServiceAccountTokenForJWTToken(serviceAccountToken string, address string, clientid string, insecure bool) (string, Error) {
 	// Create a client with NullAuth since this endpoint doesn't require authentication
-	// Use insecure=true for internal Kubernetes service communication where certificates may be self-signed
-	c := NewClient(address, NewNullAuth(), true)
+	c := NewClient(address, NewNullAuth(), insecure)
 
 	klog.V(3).Infof("Exchanging service account token for JWT")
 

--- a/auth_utils_test.go
+++ b/auth_utils_test.go
@@ -11,7 +11,7 @@ func TestExchangeServiceAccountTokenForJWTToken_Success(t *testing.T) {
 	clientID := "clientId"
 
 	// Test the function with real server
-	token, err := exchangeServiceAccountTokenForJWTToken(serviceAccountToken, address, clientID)
+	token, err := exchangeServiceAccountTokenForJWTToken(serviceAccountToken, address, clientID, false)
 
 	// Verify the result
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -159,7 +159,7 @@ func NewClientWithJWTToken(address string, jwtToken string, insecure bool) Clien
 }
 
 func NewClientWithServiceAccountToken(address string, serviceAccountToken string, clientid string, insecure bool) Client {
-	return NewClient(address, NewServiceAccountTokenAuth(serviceAccountToken, address, clientid), insecure)
+	return NewClient(address, NewServiceAccountTokenAuth(serviceAccountToken, address, clientid, insecure), insecure)
 }
 
 type client struct {

--- a/samples/complete-demo/main.go
+++ b/samples/complete-demo/main.go
@@ -106,7 +106,7 @@ func main() {
 		fmt.Println("   ✓ Client created using NewClientWithServiceAccountToken()")
 
 		// Method 2: Using auth provider
-		saAuth := client.NewServiceAccountTokenAuth(saToken, address, "client-id")
+		saAuth := client.NewServiceAccountTokenAuth(saToken, address, "client-id", false)
 		c2 := client.NewClient(address, saAuth, false)
 		fmt.Println("   ✓ Client created using NewClient() with ServiceAccountTokenAuth")
 

--- a/samples/custom-auth/main.go
+++ b/samples/custom-auth/main.go
@@ -100,7 +100,8 @@ func main() {
 	// Note: This will fail unless your backend accepts "Custom-Token" format
 	// This is just to demonstrate the concept
 	fmt.Println("Note: This custom auth format is for demonstration purposes.")
-	fmt.Println("Your backend would need to support the custom header format.\n")
+	fmt.Println("Your backend would need to support the custom header format.")
+	fmt.Println()
 
 	// Example 2: Using RotatingAuth
 	fmt.Println("Example 2: Rotating Token Authentication")

--- a/samples/service-account-auth/main.go
+++ b/samples/service-account-auth/main.go
@@ -24,7 +24,7 @@ func main() {
 
 	// Method 2: Using the base constructor with auth provider
 	fmt.Println("Creating client with service account token (Method 2)...")
-	saAuth := client.NewServiceAccountTokenAuth(saToken, address, "client-id")
+	saAuth := client.NewServiceAccountTokenAuth(saToken, address, "client-id", false)
 	client2 := client.NewClient(address, saAuth, false)
 
 	// Verify the clients work


### PR DESCRIPTION
The previous implementation hardcoded insecure=true when exchanging service account tokens for JWT tokens, ignoring the user's security preferences. This fix threads the insecure parameter through the entire call chain so it's properly respected.

Changes:
- Add insecure field to ServiceAccountTokenAuth struct
- Update NewServiceAccountTokenAuth to accept insecure parameter
- Pass insecure through to exchangeServiceAccountTokenForJWTToken
- Update all sample code and tests to use the new signature