### PR TITLE
fix: gate HTTP body/header dumps at V(5) to prevent credential leaks

### DIFF
--- a/client.go
+++ b/client.go
@@ -231,7 +231,7 @@ func (c *client) get(rawURL string) ([]byte, int, Error) {
 	}
 
 	klog.V(3).Infof("HTTP response status=%s length=%d", resp.Status, len(b))
-	klog.V(3).Infof("HTTP response body=%s", string(b))
+	klog.V(5).Infof("HTTP response body=%s", string(b))
 
 	return b, resp.StatusCode, nil
 }
@@ -286,7 +286,7 @@ func (c *client) Get(id ID, opts *GetOptions) (map[string]interface{}, Error) {
 	}
 
 	klog.V(3).Infof("HTTP response status=%s length=%d", resp.Status, len(b))
-	klog.V(3).Infof("HTTP response body=%s", string(b))
+	klog.V(5).Infof("HTTP response body=%s", string(b))
 
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		obj, err := ParseObject(b)
@@ -358,7 +358,7 @@ func (c *client) getRelationData(id ID, name string) ([]byte, Error) {
 	}
 
 	klog.V(3).Infof("HTTP response status=%s length=%d", resp.Status, len(b))
-	klog.V(3).Infof("HTTP response body=%s", string(b))
+	klog.V(5).Infof("HTTP response body=%s", string(b))
 
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		return b, nil
@@ -403,7 +403,7 @@ func (c *client) GetDescendants(id ID, path string, opts *GetOptions) ([]map[str
 	}
 
 	klog.V(3).Infof("HTTP response status=%s length=%d", resp.Status, len(b))
-	klog.V(3).Infof("HTTP response body=%s", string(b))
+	klog.V(5).Infof("HTTP response body=%s", string(b))
 
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		parseBody, err := ParseCollection(b)
@@ -476,7 +476,7 @@ func (c *client) delete(u string) Error {
 	}
 
 	klog.V(3).Infof("HTTP response status=%s length=%d", resp.Status, len(b))
-	klog.V(3).Infof("HTTP response body=%s", string(b))
+	klog.V(5).Infof("HTTP response body=%s", string(b))
 
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		return nil
@@ -520,7 +520,7 @@ func (c *client) GetCollection(service Service, modelIndex string, opts *GetOpti
 	}
 
 	klog.V(3).Infof("HTTP response status=%s length=%d", resp.Status, len(b))
-	klog.V(3).Infof("HTTP response body=%s", string(b))
+	klog.V(5).Infof("HTTP response body=%s", string(b))
 
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		body, err := ParseCollection(b)
@@ -642,7 +642,9 @@ func (c *client) buildRequest(method string, rr *RESTRequest) (*http.Request, Er
 // The caller is responsible for closing the response body.
 func (c *client) sendAndGetRawResponse(request *http.Request) (*http.Response, error) {
 	klog.V(3).Infof("HTTP request method=%s URL=%s", request.Method, request.URL.String())
-	klog.V(3).Infof("HTTP request body=%s", dumpRequest(request))
+	if klog.V(5).Enabled() {
+		klog.V(5).Infof("HTTP request body=%s", dumpRequest(request))
+	}
 
 	resp, err := c.httpClient.Do(request)
 	if err != nil {
@@ -655,7 +657,9 @@ func (c *client) sendAndGetRawResponse(request *http.Request) (*http.Response, e
 
 func (c *client) send(request *http.Request) (map[string]interface{}, Error) {
 	klog.V(3).Infof("HTTP request method=%s URL=%s", request.Method, request.URL.String())
-	klog.V(3).Infof("HTTP request body=%s", dumpRequest(request))
+	if klog.V(5).Enabled() {
+		klog.V(5).Infof("HTTP request body=%s", dumpRequest(request))
+	}
 
 	resp, err := c.httpClient.Do(request)
 	if err != nil {
@@ -670,7 +674,7 @@ func (c *client) send(request *http.Request) (map[string]interface{}, Error) {
 	}
 
 	klog.V(3).Infof("HTTP response status=%s length=%d", resp.Status, len(b))
-	klog.V(3).Infof("HTTP response body=%s", string(b))
+	klog.V(5).Infof("HTTP response body=%s", string(b))
 
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		obj, err := ParseObject(b)

--- a/client.go
+++ b/client.go
@@ -225,13 +225,12 @@ func (c *client) get(rawURL string) ([]byte, int, Error) {
 		return nil, 0, NewError("ErrorHTTP", fmt.Sprintf("HTTP %s request %s", req.Method, req.URL.String()), err)
 	}
 
-	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		klog.V(1).Infof("HTTP %d '%s': %s", resp.StatusCode, resp.Status, string(b))
-		return b, resp.StatusCode, NewError("ErrorHTTP", fmt.Sprintf("%s: %s", resp.Status, string(b)), nil)
-	}
-
 	klog.V(3).Infof("HTTP response status=%s length=%d", resp.Status, len(b))
 	klog.V(5).Infof("HTTP response body=%s", string(b))
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return b, resp.StatusCode, NewError("ErrorHTTP", resp.Status, nil)
+	}
 
 	return b, resp.StatusCode, nil
 }
@@ -296,7 +295,7 @@ func (c *client) Get(id ID, opts *GetOptions) (map[string]interface{}, Error) {
 		return obj, nil
 	}
 
-	return nil, NewError("ErrorHTTP", fmt.Sprintf("%s: %s", resp.Status, string(b)), nil)
+	return nil, NewError("ErrorHTTP", resp.Status, nil)
 }
 
 func (c *client) GetRelationID(id ID, name string) (ID, Error) {
@@ -364,7 +363,7 @@ func (c *client) getRelationData(id ID, name string) ([]byte, Error) {
 		return b, nil
 	}
 
-	return nil, NewError("ErrorHTTP", fmt.Sprintf("%s: %s", resp.Status, string(b)), nil)
+	return nil, NewError("ErrorHTTP", resp.Status, nil)
 
 }
 
@@ -413,7 +412,7 @@ func (c *client) GetDescendants(id ID, path string, opts *GetOptions) ([]map[str
 		return parseBody, nil
 	}
 
-	return nil, NewError("ErrorHTTP", fmt.Sprintf("%s: %s", resp.Status, string(b)), nil)
+	return nil, NewError("ErrorHTTP", resp.Status, nil)
 }
 
 func (c *client) GetDescendant(id ID, path string, opts *GetOptions) (map[string]interface{}, Error) {
@@ -482,7 +481,7 @@ func (c *client) delete(u string) Error {
 		return nil
 	}
 
-	return NewError("ErrorHTTP", fmt.Sprintf("%s: %s", resp.Status, string(b)), nil)
+	return NewError("ErrorHTTP", resp.Status, nil)
 }
 
 func (c *client) GetCollection(service Service, modelIndex string, opts *GetOptions) ([]map[string]interface{}, Error) {
@@ -530,7 +529,7 @@ func (c *client) GetCollection(service Service, modelIndex string, opts *GetOpti
 		return body, nil
 	}
 
-	return nil, NewError("ErrorHTTP", fmt.Sprintf("%s: %s", resp.Status, string(b)), nil)
+	return nil, NewError("ErrorHTTP", resp.Status, nil)
 }
 
 func (c *client) Post(rr *RESTRequest) (map[string]interface{}, Error) {
@@ -684,7 +683,7 @@ func (c *client) send(request *http.Request) (map[string]interface{}, Error) {
 		return obj, nil
 	}
 
-	return nil, NewError("ErrorHTTP", fmt.Sprintf("%s: %s", resp.Status, string(b)), nil)
+	return nil, NewError("ErrorHTTP", resp.Status, nil)
 }
 
 func dumpRequest(request *http.Request) string {

--- a/client_log_test.go
+++ b/client_log_test.go
@@ -92,3 +92,95 @@ func TestLogsAtV5ContainFullRequestDump(t *testing.T) {
 		t.Errorf("expected response JWT in V=5 logs for debugging, absent:\n%s", logged)
 	}
 }
+
+func errorServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		fmt.Fprint(w, `{"error":"invalid_client","client_secret":"echo-should-not-leak"}`) //nolint:errcheck
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestNon2xxBodyAbsentFromErrorMessage verifies that the raw HTTP response body
+// is not embedded in Error.Message for non-2xx responses, regardless of verbosity.
+func TestNon2xxBodyAbsentFromErrorMessage(t *testing.T) {
+	srv := errorServer(t)
+	c := NewClientWithAPIKey(srv.URL, "test-api-key", false)
+
+	// Test get() path (GetURL → get)
+	_, _, getErr := c.GetURL(ServiceUsers, "test/path")
+	if getErr == nil {
+		t.Fatal("expected error for 401 response from GetURL, got nil")
+	}
+	if strings.Contains(getErr.Message(), "echo-should-not-leak") {
+		t.Errorf("get() path: Error.Message contains response body: %s", getErr.Message())
+	}
+	if !strings.Contains(getErr.Message(), "401") {
+		t.Errorf("get() path: Error.Message should contain status code, got: %s", getErr.Message())
+	}
+
+	// Test send() path (PostFromJSON → send) — the auth/token exchange path
+	_, sendErr := c.PostFromJSON(ServiceUsers, "test/path", map[string]interface{}{}, nil)
+	if sendErr == nil {
+		t.Fatal("expected error for 401 response from PostFromJSON, got nil")
+	}
+	if strings.Contains(sendErr.Message(), "echo-should-not-leak") {
+		t.Errorf("send() path: Error.Message contains response body: %s", sendErr.Message())
+	}
+}
+
+// TestNon2xxBodyAbsentFromLogsAtV3 verifies that the response body from a
+// non-2xx response does not appear in klog output at V=3 or below.
+// At V=3, the old V(1) log would have included the body — this test catches
+// any regression of that pattern.
+func TestNon2xxBodyAbsentFromLogsAtV3(t *testing.T) {
+	srv := errorServer(t)
+	buf := captureKlogAtVerbosity(t, 3)
+
+	c := NewClientWithAPIKey(srv.URL, "test-api-key", false)
+	c.GetURL(ServiceUsers, "test/path") //nolint:errcheck
+
+	logged := buf.String()
+	if strings.Contains(logged, "echo-should-not-leak") {
+		t.Errorf("response body found in V=3 logs:\n%s", logged)
+	}
+	if !strings.Contains(logged, "HTTP response status=") {
+		t.Errorf("expected HTTP response status log at V=3, got:\n%s", logged)
+	}
+}
+
+// TestNon2xxBodyAbsentAtV4 verifies the response body is NOT present at V=4.
+// Pre-fix: V(1) body log fires at V=4 → FAIL.
+// Post-fix: V(1) log removed, V(5) log doesn't fire at V=4 → PASS.
+// This test combined with TestNon2xxBodyPresentAtV5 confirms the body moves
+// from V(1) to V(5), not that it simply disappears.
+func TestNon2xxBodyAbsentAtV4(t *testing.T) {
+	srv := errorServer(t)
+	buf := captureKlogAtVerbosity(t, 4)
+
+	c := NewClientWithAPIKey(srv.URL, "test-api-key", false)
+	c.GetURL(ServiceUsers, "test/path") //nolint:errcheck
+
+	logged := buf.String()
+	if strings.Contains(logged, "echo-should-not-leak") {
+		t.Errorf("response body found in V=4 logs:\n%s", logged)
+	}
+}
+
+// TestNon2xxBodyPresentAtV5 verifies the response body IS present at V=5,
+// so operators can diagnose non-2xx errors with -v=5.
+func TestNon2xxBodyPresentAtV5(t *testing.T) {
+	srv := errorServer(t)
+	buf := captureKlogAtVerbosity(t, 5)
+
+	c := NewClientWithAPIKey(srv.URL, "test-api-key", false)
+	c.GetURL(ServiceUsers, "test/path") //nolint:errcheck
+
+	logged := buf.String()
+	if !strings.Contains(logged, "echo-should-not-leak") {
+		t.Errorf("response body should appear in V=5 logs for debugging, absent:\n%s", logged)
+	}
+}

--- a/client_log_test.go
+++ b/client_log_test.go
@@ -1,0 +1,94 @@
+package client
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// captureKlogAtVerbosity redirects klog output to a buffer at the given verbosity
+// level. klog writes to os.Stderr by default (logtostderr=true); both the output
+// destination and the logtostderr flag must be changed together to capture V-level
+// logs in tests.
+func captureKlogAtVerbosity(t *testing.T, verbosity int) *strings.Builder {
+	t.Helper()
+	sb := &strings.Builder{}
+	fs := flag.NewFlagSet("test-klog", flag.ContinueOnError)
+	klog.InitFlags(fs)
+	fs.Set("logtostderr", "false")            //nolint:errcheck
+	fs.Set("v", fmt.Sprintf("%d", verbosity)) //nolint:errcheck
+	klog.SetOutput(sb)
+	t.Cleanup(func() {
+		klog.SetOutput(os.Stderr)
+		fs.Set("logtostderr", "true") //nolint:errcheck
+		fs.Set("v", "0")              //nolint:errcheck
+	})
+	return sb
+}
+
+func credentialServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{ //nolint:errcheck
+			"id":           "test-id-123",
+			"modelIndex":   "test",
+			"access_token": "eyJfakeResponseJWT.payload.signature",
+		})
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestLogsAtV3DoNotContainSensitiveData(t *testing.T) {
+	srv := credentialServer(t)
+	buf := captureKlogAtVerbosity(t, 3)
+
+	c := NewClientWithAPIKey(srv.URL, "super-secret-api-key-v3test", false)
+	c.PostFromJSON(ServiceUsers, "test", map[string]interface{}{ //nolint:errcheck
+		"grant_type":    "client_credentials",
+		"client_id":     "test-client",
+		"client_secret": "should-not-appear-in-logs",
+	}, nil)
+
+	logged := buf.String()
+
+	if strings.Contains(logged, "super-secret-api-key-v3test") {
+		t.Errorf("API key found in V=3 logs:\n%s", logged)
+	}
+	if strings.Contains(logged, "should-not-appear-in-logs") {
+		t.Errorf("client_secret found in V=3 logs:\n%s", logged)
+	}
+	if strings.Contains(logged, "eyJfakeResponseJWT") {
+		t.Errorf("JWT response token found in V=3 logs:\n%s", logged)
+	}
+	if !strings.Contains(logged, "HTTP") {
+		t.Errorf("expected HTTP method/URL log line at V=3, got nothing:\n%s", logged)
+	}
+}
+
+func TestLogsAtV5ContainFullRequestDump(t *testing.T) {
+	srv := credentialServer(t)
+	buf := captureKlogAtVerbosity(t, 5)
+
+	c := NewClientWithAPIKey(srv.URL, "super-secret-api-key-v5test", false)
+	c.PostFromJSON(ServiceUsers, "test", map[string]interface{}{ //nolint:errcheck
+		"client_secret": "should-appear-at-v5",
+	}, nil)
+
+	logged := buf.String()
+
+	if !strings.Contains(logged, "should-appear-at-v5") {
+		t.Errorf("expected request body in V=5 logs for debugging, absent:\n%s", logged)
+	}
+	if !strings.Contains(logged, "eyJfakeResponseJWT") {
+		t.Errorf("expected response JWT in V=5 logs for debugging, absent:\n%s", logged)
+	}
+}

--- a/client_log_test.go
+++ b/client_log_test.go
@@ -110,77 +110,61 @@ func TestNon2xxBodyAbsentFromErrorMessage(t *testing.T) {
 	srv := errorServer(t)
 	c := NewClientWithAPIKey(srv.URL, "test-api-key", false)
 
-	// Test get() path (GetURL → get)
-	_, _, getErr := c.GetURL(ServiceUsers, "test/path")
-	if getErr == nil {
-		t.Fatal("expected error for 401 response from GetURL, got nil")
-	}
-	if strings.Contains(getErr.Message(), "echo-should-not-leak") {
-		t.Errorf("get() path: Error.Message contains response body: %s", getErr.Message())
-	}
-	if !strings.Contains(getErr.Message(), "401") {
-		t.Errorf("get() path: Error.Message should contain status code, got: %s", getErr.Message())
-	}
+	t.Run("get path", func(t *testing.T) {
+		_, _, err := c.GetURL(ServiceUsers, "test/path")
+		if err == nil {
+			t.Fatal("expected error for 401 response, got nil")
+		}
+		if strings.Contains(err.Message(), "echo-should-not-leak") {
+			t.Errorf("Error.Message contains response body: %s", err.Message())
+		}
+		if !strings.Contains(err.Message(), "401") {
+			t.Errorf("Error.Message should contain status code, got: %s", err.Message())
+		}
+	})
 
-	// Test send() path (PostFromJSON → send) — the auth/token exchange path
-	_, sendErr := c.PostFromJSON(ServiceUsers, "test/path", map[string]interface{}{}, nil)
-	if sendErr == nil {
-		t.Fatal("expected error for 401 response from PostFromJSON, got nil")
-	}
-	if strings.Contains(sendErr.Message(), "echo-should-not-leak") {
-		t.Errorf("send() path: Error.Message contains response body: %s", sendErr.Message())
-	}
+	t.Run("send path", func(t *testing.T) {
+		_, err := c.PostFromJSON(ServiceUsers, "test/path", map[string]interface{}{}, nil)
+		if err == nil {
+			t.Fatal("expected error for 401 response, got nil")
+		}
+		if strings.Contains(err.Message(), "echo-should-not-leak") {
+			t.Errorf("Error.Message contains response body: %s", err.Message())
+		}
+	})
 }
 
-// TestNon2xxBodyAbsentFromLogsAtV3 verifies that the response body from a
-// non-2xx response does not appear in klog output at V=3 or below.
-// At V=3, the old V(1) log would have included the body — this test catches
-// any regression of that pattern.
-func TestNon2xxBodyAbsentFromLogsAtV3(t *testing.T) {
-	srv := errorServer(t)
-	buf := captureKlogAtVerbosity(t, 3)
-
-	c := NewClientWithAPIKey(srv.URL, "test-api-key", false)
-	c.GetURL(ServiceUsers, "test/path") //nolint:errcheck
-
-	logged := buf.String()
-	if strings.Contains(logged, "echo-should-not-leak") {
-		t.Errorf("response body found in V=3 logs:\n%s", logged)
+// TestNon2xxBodyLogVisibility verifies that non-2xx response bodies are absent
+// from logs below V=5 and present at V=5.
+func TestNon2xxBodyLogVisibility(t *testing.T) {
+	tests := []struct {
+		verbosity   int
+		wantBody    bool
+		checkStatus bool // V=3 additionally verifies the response-status log line is present
+	}{
+		{3, false, true},
+		{4, false, false},
+		{5, true, false},
 	}
-	if !strings.Contains(logged, "HTTP response status=") {
-		t.Errorf("expected HTTP response status log at V=3, got:\n%s", logged)
-	}
-}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(fmt.Sprintf("V%d", tc.verbosity), func(t *testing.T) {
+			srv := errorServer(t)
+			buf := captureKlogAtVerbosity(t, tc.verbosity)
 
-// TestNon2xxBodyAbsentAtV4 verifies the response body is NOT present at V=4.
-// Pre-fix: V(1) body log fires at V=4 → FAIL.
-// Post-fix: V(1) log removed, V(5) log doesn't fire at V=4 → PASS.
-// This test combined with TestNon2xxBodyPresentAtV5 confirms the body moves
-// from V(1) to V(5), not that it simply disappears.
-func TestNon2xxBodyAbsentAtV4(t *testing.T) {
-	srv := errorServer(t)
-	buf := captureKlogAtVerbosity(t, 4)
+			c := NewClientWithAPIKey(srv.URL, "test-api-key", false)
+			c.GetURL(ServiceUsers, "test/path") //nolint:errcheck
 
-	c := NewClientWithAPIKey(srv.URL, "test-api-key", false)
-	c.GetURL(ServiceUsers, "test/path") //nolint:errcheck
-
-	logged := buf.String()
-	if strings.Contains(logged, "echo-should-not-leak") {
-		t.Errorf("response body found in V=4 logs:\n%s", logged)
-	}
-}
-
-// TestNon2xxBodyPresentAtV5 verifies the response body IS present at V=5,
-// so operators can diagnose non-2xx errors with -v=5.
-func TestNon2xxBodyPresentAtV5(t *testing.T) {
-	srv := errorServer(t)
-	buf := captureKlogAtVerbosity(t, 5)
-
-	c := NewClientWithAPIKey(srv.URL, "test-api-key", false)
-	c.GetURL(ServiceUsers, "test/path") //nolint:errcheck
-
-	logged := buf.String()
-	if !strings.Contains(logged, "echo-should-not-leak") {
-		t.Errorf("response body should appear in V=5 logs for debugging, absent:\n%s", logged)
+			logged := buf.String()
+			if tc.wantBody && !strings.Contains(logged, "echo-should-not-leak") {
+				t.Errorf("response body should appear in V=%d logs, absent:\n%s", tc.verbosity, logged)
+			}
+			if !tc.wantBody && strings.Contains(logged, "echo-should-not-leak") {
+				t.Errorf("response body found in V=%d logs:\n%s", tc.verbosity, logged)
+			}
+			if tc.checkStatus && !strings.Contains(logged, "HTTP response status=") {
+				t.Errorf("expected HTTP response status log at V=%d, got:\n%s", tc.verbosity, logged)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- `httputil.DumpRequest(req, true)` was called at `klog.V(3)` in `send()` and `sendAndGetRawResponse()`, dumping full HTTP request messages including `Authorization` headers (Bearer JWTs, NIRMATA-API keys) and request bodies — leaking `client_secret` from the service account token-exchange endpoint
- Response bodies (including returned JWTs and auth tokens) were also logged at V(3) across all HTTP methods
- Common operator debug verbosity `-v=3` was sufficient to trigger all three leaks

## Changes

- Moved all HTTP body/header log lines from `klog.V(3)` to `klog.V(5)`
- Wrapped `dumpRequest()` callsites in `if klog.V(5).Enabled()` to prevent the `httputil.DumpRequest` body-read allocation on every POST/PUT when V<5
- Added `TestLogsAtV3DoNotContainSensitiveData` and `TestLogsAtV5ContainFullRequestDump` to lock in the behavior

## Test plan

- [ ] `GOWORK=off go test -run TestLogsAt ./...` — both new tests pass
- [ ] Deploy agent-executor with `-v=3`, make a Nirmata-provider chat call, `grep -i 'bearer\|client_secret\|eyJ'` on pod logs — expect no matches
- [ ] Repeat with `-v=5` — full request/response dump should appear

## Consumers

After this release, `go-llm-apps` should bump `github.com/nirmata/go-client` and cut a new release; `ottoflow` then bumps `go-llm-apps`. Other consumers (nctl, go-service-agent) pick up the fix on their next dep bump.

Fixes nirmata/ottoflow#98 and #22 