### PR TITLE
feat: add HTTPClient to ServiceClientConfig + GetUserByAPIKeyWithConfig

### DIFF
--- a/serviceclient.go
+++ b/serviceclient.go
@@ -103,7 +103,7 @@ func (sc *ServiceClient) Get(path string) ([]byte, int, Error) {
 	}
 
 	req.Header.Add("Authorization", fmt.Sprintf("%s %s", ServiceAccountAuthScheme, sc.saToken))
-	klog.V(3).Infof("ServiceClient GET %s", strings.SplitN(url, "?", 2)[0])
+	klog.V(3).Infof("ServiceClient GET service=%s", sc.service.Name())
 	return sc.doRequest(req)
 }
 
@@ -119,7 +119,7 @@ func (sc *ServiceClient) Post(path string, contentType string, data []byte) ([]b
 	if contentType != "" {
 		req.Header.Set("Content-Type", contentType)
 	}
-	klog.V(3).Infof("ServiceClient POST %s", strings.SplitN(url, "?", 2)[0])
+	klog.V(3).Infof("ServiceClient POST service=%s", sc.service.Name())
 	return sc.doRequest(req)
 }
 
@@ -135,7 +135,7 @@ func (sc *ServiceClient) Put(path string, contentType string, data []byte) ([]by
 	if contentType != "" {
 		req.Header.Set("Content-Type", contentType)
 	}
-	klog.V(3).Infof("ServiceClient PUT %s", strings.SplitN(url, "?", 2)[0])
+	klog.V(3).Infof("ServiceClient PUT service=%s", sc.service.Name())
 	return sc.doRequest(req)
 }
 

--- a/serviceclient.go
+++ b/serviceclient.go
@@ -103,7 +103,7 @@ func (sc *ServiceClient) Get(path string) ([]byte, int, Error) {
 	}
 
 	req.Header.Add("Authorization", fmt.Sprintf("%s %s", ServiceAccountAuthScheme, sc.saToken))
-	klog.V(3).Infof("ServiceClient GET %s", url)
+	klog.V(3).Infof("ServiceClient GET %s", strings.SplitN(url, "?", 2)[0])
 	return sc.doRequest(req)
 }
 
@@ -119,7 +119,7 @@ func (sc *ServiceClient) Post(path string, contentType string, data []byte) ([]b
 	if contentType != "" {
 		req.Header.Set("Content-Type", contentType)
 	}
-	klog.V(3).Infof("ServiceClient POST %s", url)
+	klog.V(3).Infof("ServiceClient POST %s", strings.SplitN(url, "?", 2)[0])
 	return sc.doRequest(req)
 }
 
@@ -135,7 +135,7 @@ func (sc *ServiceClient) Put(path string, contentType string, data []byte) ([]by
 	if contentType != "" {
 		req.Header.Set("Content-Type", contentType)
 	}
-	klog.V(3).Infof("ServiceClient PUT %s", url)
+	klog.V(3).Infof("ServiceClient PUT %s", strings.SplitN(url, "?", 2)[0])
 	return sc.doRequest(req)
 }
 
@@ -148,7 +148,7 @@ func (sc *ServiceClient) Delete(path string) ([]byte, int, Error) {
 	}
 
 	req.Header.Add("Authorization", fmt.Sprintf("%s %s", ServiceAccountAuthScheme, sc.saToken))
-	klog.V(3).Infof("ServiceClient DELETE %s", url)
+	klog.V(3).Infof("ServiceClient DELETE %s", strings.SplitN(url, "?", 2)[0])
 	return sc.doRequest(req)
 }
 

--- a/serviceclient.go
+++ b/serviceclient.go
@@ -148,7 +148,7 @@ func (sc *ServiceClient) Delete(path string) ([]byte, int, Error) {
 	}
 
 	req.Header.Add("Authorization", fmt.Sprintf("%s %s", ServiceAccountAuthScheme, sc.saToken))
-	klog.V(3).Infof("ServiceClient DELETE %s", strings.SplitN(url, "?", 2)[0])
+	klog.V(3).Infof("ServiceClient DELETE service=%s", sc.service.Name())
 	return sc.doRequest(req)
 }
 

--- a/serviceclient.go
+++ b/serviceclient.go
@@ -30,6 +30,10 @@ type ServiceClientConfig struct {
 	Service                 Service
 	Address                 string // Base URL. Defaults to "https://" (internal K8s pattern)
 	ServiceAccountTokenPath string // Defaults to /var/run/secrets/kubernetes.io/serviceaccount/token
+	// HTTPClient overrides the default HTTP client. When set, the caller is
+	// responsible for TLS configuration (e.g. a SPIRE mTLS transport).
+	// When nil, a default client with InsecureSkipVerify=true is used.
+	HTTPClient *http.Client
 }
 
 // NewServiceClient creates a new ServiceClient for service-to-service communication
@@ -57,11 +61,16 @@ func NewServiceClient(config ServiceClientConfig) (*ServiceClient, error) {
 	}
 	saToken := strings.TrimSpace(string(tokenBytes))
 
-	// Skip TLS verification for internal service-to-service communication (matches Java behavior)
-	httpClient := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
-		},
+	httpClient := config.HTTPClient
+	if httpClient == nil {
+		// Default: skip TLS verification for internal service-to-service
+		// communication (matches Java behaviour). Callers that need mTLS
+		// should supply a transport via ServiceClientConfig.HTTPClient.
+		httpClient = &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+			},
+		}
 	}
 
 	klog.V(2).Infof("Created ServiceClient: target=%s, address=%s", config.Service.Name(), address)

--- a/serviceclients/usersclient.go
+++ b/serviceclients/usersclient.go
@@ -75,12 +75,24 @@ func (c *UsersClient) GetCurrentUserWithAPIKey(apiKey string) (User, error) {
 	}, nil
 }
 
-// GetUserByAPIKey retrieves a user by API key using service-to-service authentication
+// GetUserByAPIKey retrieves a user by API key using service-to-service
+// authentication. The default InsecureSkipVerify HTTP client is used.
+// Use GetUserByAPIKeyWithConfig to supply a custom HTTP client (e.g. SPIRE mTLS).
 func GetUserByAPIKey(apiKey string, address string) (User, error) {
-	serviceClient, err := client.NewServiceClient(client.ServiceClientConfig{
+	return GetUserByAPIKeyWithConfig(apiKey, client.ServiceClientConfig{
 		Service: client.ServiceUsers,
 		Address: address,
 	})
+}
+
+// GetUserByAPIKeyWithConfig retrieves a user by API key using the provided
+// ServiceClientConfig. Set ServiceClientConfig.HTTPClient to inject a custom
+// transport such as a SPIRE mTLS RoundTripper.
+func GetUserByAPIKeyWithConfig(apiKey string, config client.ServiceClientConfig) (User, error) {
+	if config.Service == 0 {
+		config.Service = client.ServiceUsers
+	}
+	serviceClient, err := client.NewServiceClient(config)
 	if err != nil {
 		return User{}, fmt.Errorf("failed to create service client: %w", err)
 	}


### PR DESCRIPTION
## Summary

Allows callers to inject a custom `http.RoundTripper` (e.g. a SPIRE mTLS transport) into the `ServiceClient` instead of the hardcoded `InsecureSkipVerify` default.

### Changes

**`serviceclient.go`**
- `ServiceClientConfig.HTTPClient *http.Client` — optional override. When `nil`, existing `InsecureSkipVerify` behaviour is unchanged (full backward compat).

**`serviceclients/usersclient.go`**
- `GetUserByAPIKeyWithConfig(apiKey string, config ServiceClientConfig) (User, error)` — new function accepting a full config so callers can set `HTTPClient`.
- `GetUserByAPIKey` is now a thin wrapper over it, signature unchanged.

### Motivation

`go-llm-apps` calls `GetUserByAPIKey` to validate API keys against `java-users`. As part of the SPIRE mTLS rollout, `go-llm-apps` needs to present its SVID on this outbound call. Without this change there was no way to inject the SPIRE transport into the `ServiceClient`.

Closes go-llm-apps#977 (follow-up).